### PR TITLE
Correct staking periods to current 30-667 day range

### DIFF
--- a/docs/protocol/staking/staking.md
+++ b/docs/protocol/staking/staking.md
@@ -24,20 +24,20 @@ NXM stakers do not control how their NXM is allocated within a staking pool, tho
 
 When someone decides to stake their NXM, they need to choose the length of time that their NXM will be locked in a staking pool: this is referred to as the staking period.
 
-Members can choose to stake their NXM for as little as 91 days or as long as two years. There are a total of eight staking periods to choose from. Members are able to delegate their NXM to multiple staking pools and for multiple staking periods.
+Members can choose to stake their NXM for as little as 30 days or as long as almost two years. There are a total of eight staking periods to choose from. Members are able to delegate their NXM to multiple staking pools and for multiple staking periods.
 
 | Staking Period # | Days |
 | :--------------: | :--: |
-| 1                | 91   |
-| 2                | 182  |
-| 3                | 273  |
-| 4                | 364  |
-| 5                | 455  |
-| 6                | 546  |
-| 7                | 637  |
-| 8                | 728  |
+| 1                | 30   |
+| 2                | 121  |
+| 3                | 212  |
+| 4                | 303  |
+| 5                | 394  |
+| 6                | 485  |
+| 7                | 576  |
+| 8                | 667  |
 
-Each staking period will have a fixed date range, so all NXM delegated in one staking period will expire at the same time. If a member delegates their staked NXM to Staking Period #1 noted above 20 days into the 91-day period, then their staked NXM would be subject to a 71-day lockup when Staking Period #1 ends and members can withdraw their NXM.
+Each staking period will have a fixed date range, so all NXM delegated in one staking period will expire at the same time. If a member delegates their staked NXM to Staking Period #1 noted above 20 days into the 121-day period, then their staked NXM would be subject to a 101-day lockup when Staking Period #1 ends and members can withdraw their NXM.
 
 ## Tokenized staking positions
 


### PR DESCRIPTION
I noticed the current staking period list was actually 61 days shorter than as described in the docs, so propose to update this section.

I was also slightly confused by the final paragraph in this section:

`Each staking period will have a fixed date range, so all NXM delegated in one staking period will expire at the same time. If a member delegates their staked NXM to Staking Period #1 noted above 20 days into the 121-day period, then their staked NXM would be subject to a 101-day lockup when Staking Period #1 ends and members can withdraw their NXM.`

This appears to suggest that there is a 101-day lockup after the current 121-day staking period ends. Perhaps I'm reading it wrong?

Our understanding was as follows:

`Each delegated staking position will have a fixed date range, meaning that all NXM staked as part of that delegation position will expire at the same time. For example, if a member had delegated to Staking Pool #1 for 30 days, and then opts to updates their delegation to Staking Pool #1 after 7 days by staking more NXM, the duration of their whole position will be extended from 23 days (initial 30 days with 7 days elapsed) back to 30 days.`

Thanks! 🙏 