### PR TITLE
Normalize sidebar_position and reorder top-level sections

### DIFF
--- a/docs/developers/Diagrams/Contracts Diagrams/_category_.json
+++ b/docs/developers/Diagrams/Contracts Diagrams/_category_.json
@@ -1,0 +1,4 @@
+{
+  "label": "Contracts Diagrams",
+  "position": 1
+}

--- a/docs/developers/Diagrams/Contracts Diagrams/capital.md
+++ b/docs/developers/Diagrams/Contracts Diagrams/capital.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 10.6
+sidebar_position: 1
 ---
 
 # Capital Contracts

--- a/docs/developers/Diagrams/Contracts Diagrams/claims-assessment.md
+++ b/docs/developers/Diagrams/Contracts Diagrams/claims-assessment.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 10.7
+sidebar_position: 2
 ---
 
 # Claims & Assessment

--- a/docs/developers/Diagrams/Contracts Diagrams/cover.md
+++ b/docs/developers/Diagrams/Contracts Diagrams/cover.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 10.8
+sidebar_position: 3
 ---
 
 # Cover Contracts

--- a/docs/developers/Diagrams/Contracts Diagrams/governance-membership.md
+++ b/docs/developers/Diagrams/Contracts Diagrams/governance-membership.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 10.9
+sidebar_position: 4
 ---
 
 # Governance & Membership Contracts

--- a/docs/developers/Diagrams/Contracts Diagrams/staking.md
+++ b/docs/developers/Diagrams/Contracts Diagrams/staking.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 11
+sidebar_position: 5
 ---
 
 # Staking Contracts

--- a/docs/developers/Diagrams/Contracts Diagrams/token.md
+++ b/docs/developers/Diagrams/Contracts Diagrams/token.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 11.1
+sidebar_position: 6
 ---
 
 # Token Contracts

--- a/docs/developers/Diagrams/Diagrams.md
+++ b/docs/developers/Diagrams/Diagrams.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 10.5
+sidebar_position: 3
 ---
 
 # Diagrams

--- a/docs/developers/Diagrams/User Flows Diagrams/_category_.json
+++ b/docs/developers/Diagrams/User Flows Diagrams/_category_.json
@@ -1,0 +1,4 @@
+{
+  "label": "User Flows Diagrams",
+  "position": 2
+}

--- a/docs/developers/Diagrams/User Flows Diagrams/cover-buyer.md
+++ b/docs/developers/Diagrams/User Flows Diagrams/cover-buyer.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 11.2
+sidebar_position: 1
 ---
 
 # Cover Buyer / Claims Flow

--- a/docs/developers/Diagrams/User Flows Diagrams/staker.md
+++ b/docs/developers/Diagrams/User Flows Diagrams/staker.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 11.3
+sidebar_position: 2
 ---
 
 # Staker Flow

--- a/docs/developers/Diagrams/User Flows Diagrams/staking-manager.md
+++ b/docs/developers/Diagrams/User Flows Diagrams/staking-manager.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 11.4
+sidebar_position: 3
 ---
 
 # Staking Pool Manager Flow

--- a/docs/developers/Restaking/Symbiotic.md
+++ b/docs/developers/Restaking/Symbiotic.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 1
+---
+
 # Symbiotic Vault Onboarding
 
 ## Overview

--- a/docs/developers/Restaking/_category_.json
+++ b/docs/developers/Restaking/_category_.json
@@ -1,0 +1,4 @@
+{
+  "label": "Restaking",
+  "position": 4
+}

--- a/docs/developers/User Flows/_category_.json
+++ b/docs/developers/User Flows/_category_.json
@@ -1,0 +1,4 @@
+{
+  "label": "User Flows",
+  "position": 5
+}

--- a/docs/developers/User Flows/cover-buyer.md
+++ b/docs/developers/User Flows/cover-buyer.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 10.2
+sidebar_position: 1
 ---
 
 # Cover Buyer User Flow

--- a/docs/developers/User Flows/manager.md
+++ b/docs/developers/User Flows/manager.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 10.3
+sidebar_position: 2
 ---
 
 # Manager User Flow

--- a/docs/developers/User Flows/staker.md
+++ b/docs/developers/User Flows/staker.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 10.4
+sidebar_position: 3
 ---
 
 # NXM Staker User Flow

--- a/docs/developers/contracts/Assessment.md
+++ b/docs/developers/contracts/Assessment.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 9.3
+sidebar_position: 1
 ---
 
 # Assessment

--- a/docs/developers/contracts/Cover.md
+++ b/docs/developers/contracts/Cover.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 9.4
+sidebar_position: 2
 ---
 
 # Cover

--- a/docs/developers/contracts/IndividualClaims.md
+++ b/docs/developers/contracts/IndividualClaims.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 9.5
+sidebar_position: 3
 ---
 
 # IndividualClaims

--- a/docs/developers/contracts/Pool.md
+++ b/docs/developers/contracts/Pool.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 9.6
+sidebar_position: 4
 ---
 
 # Pool

--- a/docs/developers/contracts/Ramm.md
+++ b/docs/developers/contracts/Ramm.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 9.7
+sidebar_position: 5
 ---
 
 # RAMM

--- a/docs/developers/contracts/StakingPool.md
+++ b/docs/developers/contracts/StakingPool.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 9.8
+sidebar_position: 6
 ---
 
 # StakingPool

--- a/docs/developers/contracts/StakingPoolFactory.md
+++ b/docs/developers/contracts/StakingPoolFactory.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 9.9
+sidebar_position: 7
 ---
 
 # StakingPoolFactory

--- a/docs/developers/contracts/StakingProducts.md
+++ b/docs/developers/contracts/StakingProducts.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 10
+sidebar_position: 8
 ---
 
 # StakingProducts

--- a/docs/developers/contracts/TokenController.md
+++ b/docs/developers/contracts/TokenController.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 10.1
+sidebar_position: 9
 ---
 
 # TokenController

--- a/docs/developers/contracts/contracts.md
+++ b/docs/developers/contracts/contracts.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 9.2
+sidebar_position: 2
 ---
 
 # Contracts

--- a/docs/developers/developers.md
+++ b/docs/developers/developers.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 9
+sidebar_position: 5
 ---
 
 # Developer Resources

--- a/docs/developers/pos-integrations.md
+++ b/docs/developers/pos-integrations.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 9.1
+sidebar_position: 1
 ---
 
 # Point-of-Sale (PoS) Integrations

--- a/docs/governance/dao.md
+++ b/docs/governance/dao.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 8.1
+sidebar_position: 1
 ---
 
 # Nexus Mutual DAO

--- a/docs/governance/governance.md
+++ b/docs/governance/governance.md
@@ -1,5 +1,5 @@
 ---
-Sidebar_position: 8
+sidebar_position: 6
 ---
 
 # Governance

--- a/docs/overview/claims-history/blockfi.md
+++ b/docs/overview/claims-history/blockfi.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 3.8
+sidebar_position: 8
 ---
 
 # BlockFi Halted Withdrawals | November 2022

--- a/docs/overview/claims-history/bzx-2020.md
+++ b/docs/overview/claims-history/bzx-2020.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 3.1
+sidebar_position: 1
 ---
 
 # bZx hack | February 2020

--- a/docs/overview/claims-history/cream-2021.md
+++ b/docs/overview/claims-history/cream-2021.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 3.3
+sidebar_position: 3
 ---
 
 # CREAM V1 Economic Exploit | October 2021

--- a/docs/overview/claims-history/euler.md
+++ b/docs/overview/claims-history/euler.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 3.9
+sidebar_position: 9
 ---
 
 # Euler Finance Exploit | March 2023

--- a/docs/overview/claims-history/ftx.md
+++ b/docs/overview/claims-history/ftx.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 3.7
+sidebar_position: 7
 ---
 
 # FTX Halted Withdrawals | November 2022

--- a/docs/overview/claims-history/hodlnaut-2022.md
+++ b/docs/overview/claims-history/hodlnaut-2022.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 3.6
+sidebar_position: 6
 ---
 
 # Hodlnaut Halted Withdrawals | August 2022

--- a/docs/overview/claims-history/perpetual-2022.md
+++ b/docs/overview/claims-history/perpetual-2022.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 3.5
+sidebar_position: 5
 ---
 
 # Perpetual Protocol v1 Economic Design Failure | May 2022

--- a/docs/overview/claims-history/rari-fuse-2022.md
+++ b/docs/overview/claims-history/rari-fuse-2022.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 3.4
+sidebar_position: 4
 ---
 
 # TribeDAO, Rari Capital Fuse Market Hack | April 2022

--- a/docs/overview/claims-history/yearn-2021.md
+++ b/docs/overview/claims-history/yearn-2021.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 3.2
+sidebar_position: 2
 ---
 
 # Yearn yDAI Hack | February 2021

--- a/docs/overview/cover-products/bundled-protocol-cover.md
+++ b/docs/overview/cover-products/bundled-protocol-cover.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 1.5
+sidebar_position: 2
 ---
 
 # Multi Protocol Cover

--- a/docs/overview/cover-products/cover-products.md
+++ b/docs/overview/cover-products/cover-products.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 1.3
+sidebar_position: 2
 ---
 
 # Cover Products

--- a/docs/overview/cover-products/defi-pass-cover.md
+++ b/docs/overview/cover-products/defi-pass-cover.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 1.6
+sidebar_position: 3
 ---
 
 # DeFi Pass Cover

--- a/docs/overview/cover-products/eth-slashing-cover.md
+++ b/docs/overview/cover-products/eth-slashing-cover.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 1.9
+sidebar_position: 6
 ---
 
 # ETH Slashing Cover

--- a/docs/overview/cover-products/fund-portfolio-cover.md
+++ b/docs/overview/cover-products/fund-portfolio-cover.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 1.8
+sidebar_position: 5
 ---
 
 # Fund Portfolio Cover

--- a/docs/overview/cover-products/native-protocol-cover.md
+++ b/docs/overview/cover-products/native-protocol-cover.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 1.7
+sidebar_position: 4
 ---
 
 # Native Protocol Cover

--- a/docs/overview/cover-products/protocol-cover.md
+++ b/docs/overview/cover-products/protocol-cover.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 1.4
+sidebar_position: 1
 ---
 
 # Single Protocol Cover

--- a/docs/overview/cover-products/quota-share-cover.md
+++ b/docs/overview/cover-products/quota-share-cover.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 2.0
+sidebar_position: 7
 ---
 
 # Quota Share Cover

--- a/docs/overview/cover-products/real-world-risk.md
+++ b/docs/overview/cover-products/real-world-risk.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 2.1
+sidebar_position: 8
 ---
 
 # Real World Risk

--- a/docs/overview/membership.md
+++ b/docs/overview/membership.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 1.2
+sidebar_position: 1
 ---
 
 # Membership

--- a/docs/overview/overview.md
+++ b/docs/overview/overview.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 1.1
+sidebar_position: 2
 ---
 
 # Overview

--- a/docs/protocol/capacity.md
+++ b/docs/protocol/capacity.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 5.9
+sidebar_position: 5
 ---
 
 # Capacity

--- a/docs/protocol/capital-pool/capital-pool.md
+++ b/docs/protocol/capital-pool/capital-pool.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: Capital Pool
-sidebar_position: 5.4
+sidebar_position: 2
 ---
 
 # Capital Pool

--- a/docs/protocol/capital-pool/investments.md
+++ b/docs/protocol/capital-pool/investments.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 5.5
+sidebar_position: 1
 ---
 
 # Investments

--- a/docs/protocol/capital-pool/mcr.md
+++ b/docs/protocol/capital-pool/mcr.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 5.6
+sidebar_position: 2
 ---
 
 # Minimum Capital Requirement

--- a/docs/protocol/claims-assessment.md
+++ b/docs/protocol/claims-assessment.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 6.2
+sidebar_position: 7
 ---
 
 # Claim Assessment

--- a/docs/protocol/cover.md
+++ b/docs/protocol/cover.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 5.7
+sidebar_position: 3
 ---
 
 # Cover

--- a/docs/protocol/integrations.md
+++ b/docs/protocol/integrations.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 6.3
+sidebar_position: 8
 ---
 
 # Integrations

--- a/docs/protocol/nxm-token/history-capitalisation-controls.md
+++ b/docs/protocol/nxm-token/history-capitalisation-controls.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 5.3
+sidebar_position: 2
 ---
 
 # History of Capitalisation Controls

--- a/docs/protocol/nxm-token/nxm-token.md
+++ b/docs/protocol/nxm-token/nxm-token.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: NXM Token
-sidebar_position: 5.1
+sidebar_position: 1
 ---
 
 # NXM Token

--- a/docs/protocol/nxm-token/token-model.md
+++ b/docs/protocol/nxm-token/token-model.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 5.2
+sidebar_position: 1
 ---
 
 # Token Model

--- a/docs/protocol/pricing.md
+++ b/docs/protocol/pricing.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 5.8
+sidebar_position: 4
 ---
 
 # Pricing

--- a/docs/protocol/protocol.md
+++ b/docs/protocol/protocol.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 7
+sidebar_position: 3
 ---
 
 # The Nexus Mutual Protocol

--- a/docs/protocol/staking/staking-pools.md
+++ b/docs/protocol/staking/staking-pools.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 6.1
+sidebar_position: 1
 ---
 
 # Staking pools

--- a/docs/resources/audits-and-security.md
+++ b/docs/resources/audits-and-security.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 7.1
+sidebar_position: 1
 ---
 
 # Audits and Security

--- a/docs/resources/faq.md
+++ b/docs/resources/faq.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 7.2
+sidebar_position: 2
 ---
 
 # FAQ

--- a/docs/resources/resources.md
+++ b/docs/resources/resources.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 7
+sidebar_position: 4
 ---
 
 # Resources

--- a/docs/rwi-vault/approval.md
+++ b/docs/rwi-vault/approval.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 8.1
+sidebar_position: 1
 ---
 
 # Depositor Approval

--- a/docs/rwi-vault/depositing.md
+++ b/docs/rwi-vault/depositing.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 8.2
+sidebar_position: 2
 ---
 
 # Depositing USDC

--- a/docs/rwi-vault/faqs.md
+++ b/docs/rwi-vault/faqs.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 8.7
+sidebar_position: 7
 ---
 
 # FAQs

--- a/docs/rwi-vault/insurance-partners.md
+++ b/docs/rwi-vault/insurance-partners.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 8.3
+sidebar_position: 3
 ---
 
 # Insurance Partners

--- a/docs/rwi-vault/risks.md
+++ b/docs/rwi-vault/risks.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 8.6
+sidebar_position: 6
 ---
 
 # Risks

--- a/docs/rwi-vault/rwi-vault.md
+++ b/docs/rwi-vault/rwi-vault.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 8
+sidebar_position: 7
 ---
 
 # Real World Insurance Vault

--- a/docs/rwi-vault/withdrawals.md
+++ b/docs/rwi-vault/withdrawals.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 8.5
+sidebar_position: 5
 ---
 
 # Withdrawals

--- a/docs/rwi-vault/yield-structure/baseline-yield/nexus-mutual-cover.md
+++ b/docs/rwi-vault/yield-structure/baseline-yield/nexus-mutual-cover.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 2
+sidebar_position: 1
 ---
 
 # Nexus Mutual Cover

--- a/docs/rwi-vault/yield-structure/bonuses/bonuses.md
+++ b/docs/rwi-vault/yield-structure/bonuses/bonuses.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 1
+sidebar_position: 2
 ---
 
 # Bonuses

--- a/docs/rwi-vault/yield-structure/bonuses/nav-calculation.md
+++ b/docs/rwi-vault/yield-structure/bonuses/nav-calculation.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 2
+sidebar_position: 1
 ---
 
 # Net Asset Value Calculation

--- a/docs/rwi-vault/yield-structure/yield-structure.md
+++ b/docs/rwi-vault/yield-structure/yield-structure.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 8.4
+sidebar_position: 4
 ---
 
 # Yield Structure


### PR DESCRIPTION
## Summary

Follow-up to #87. That PR fixed the broken build; this PR normalizes the underlying numbering scheme and rearranges the top-level sections, with no change to the rendered sidebar order beyond what's described below.

### 1. `sidebar_position` normalization

The previous outline-style numbering scheme (`1.1`, `1.2`, ..., `5.7`, ..., `7.1`, `8.1`, ...) mixed scopes from different directory levels into one global sequence. Docusaurus orders items per-directory only, so the global numbering provided no value and was error-prone -- the build-breaking `8.4.1` fixed in #87 is one such case.

Every directory's children are now consecutive integers `1..N` in their existing rendered order. **The visible sidebar order within each section is unchanged.**

For sub-categories with no `<dirname>.md` index doc, an explicit `_category_.json` was added so the position within the parent is defined explicitly rather than implicitly via children:

- `docs/developers/Diagrams/Contracts Diagrams/_category_.json`
- `docs/developers/Diagrams/User Flows Diagrams/_category_.json`
- `docs/developers/Restaking/_category_.json`
- `docs/developers/User Flows/_category_.json`

### 2. Top-level section reorder

`governance/governance.md` had a front-matter typo (`Sidebar_position` with capital S) which Docusaurus silently ignored, pushing Governance to the end of the sidebar alphabetically. Typo fixed and the top-level layout adjusted: Developer Resources moved next to Resources; RWI Vault placed after Governance.

Final top-level order:

1. Getting Started
2. Overview
3. The Nexus Mutual Protocol
4. Resources
5. Developer Resources
6. Governance
7. Real World Insurance Vault

### Verification

```
$ npm run build
...
[SUCCESS] Generated static files in "build".
```

Per-directory positions audited: `1..N` consecutive in 19 directories, no gaps, no duplicates, no decimals.

## Test plan

- [ ] `npm run build` succeeds with no errors
- [ ] Top-level sidebar order: Getting Started -> Overview -> Protocol -> Resources -> Developer Resources -> Governance -> RWI Vault
- [ ] Sidebar order within each section is unchanged (only the underlying numeric values changed)