### PR TITLE
ci: report when the contract reference drifts from the deployed contracts

### DIFF
--- a/.github/workflows/contract-docs-drift.yml
+++ b/.github/workflows/contract-docs-drift.yml
@@ -37,8 +37,11 @@ jobs:
           npm ci --ignore-scripts
           npm install --no-save @nexusmutual/deployments@latest
 
-      - name: Check contract reference against deployed ABIs
+      - name: Check contract reference against deployed contracts
         id: check
+        env:
+          # Optional. Falls back to a public endpoint when unset.
+          ETH_RPC_URL: ${{ secrets.ETH_RPC_URL }}
         run: |
           set +e
           npm run --silent check:contract-docs > report.txt 2>&1

--- a/.github/workflows/contract-docs-drift.yml
+++ b/.github/workflows/contract-docs-drift.yml
@@ -1,0 +1,133 @@
+name: Contract docs drift
+
+# Reports when the contract reference no longer matches the deployed contracts.
+#
+# Runs on pull requests, and weekly so that drift introduced by a contract
+# release is found without waiting for someone to edit the docs.
+#
+# This check reports, it does not gate. Keep it out of the required status
+# checks so that a contract release cannot block unrelated documentation work.
+
+on:
+  pull_request:
+    branches: [master]
+  schedule:
+    # Mondays, 08:00 UTC
+    - cron: '0 8 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      # Resolve the latest published deployments rather than the pinned range,
+      # so a contract release shows up here without a dependency bump.
+      - name: Install
+        run: |
+          npm ci --ignore-scripts
+          npm install --no-save @nexusmutual/deployments@latest
+
+      - name: Check contract reference against deployed ABIs
+        id: check
+        run: |
+          set +e
+          npm run --silent check:contract-docs > report.txt 2>&1
+          echo "exit_code=$?" >> "$GITHUB_OUTPUT"
+          cat report.txt
+          {
+            echo '### Contract docs drift'
+            echo '```'
+            cat report.txt
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Open or update the tracking issue
+        if: steps.check.outputs.exit_code != '0' && github.event_name != 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const report = fs.readFileSync('report.txt', 'utf8');
+            const title = 'Contract docs drift: the reference no longer matches the deployed contracts';
+            const body = [
+              'The contract reference documents functions that are absent from the deployed ABIs.',
+              '',
+              'Latest run:',
+              '',
+              '```',
+              report.trim(),
+              '```',
+              '',
+              `Checked by [\`${context.workflow}\`](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}).`,
+              'This issue is updated in place on each run.',
+            ].join('\n');
+
+            const existing = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'contract-docs-drift',
+            });
+
+            if (existing.data.length > 0) {
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existing.data[0].number,
+                body,
+              });
+              core.info(`Updated issue #${existing.data[0].number}`);
+              return;
+            }
+
+            const created = await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title,
+              body,
+              labels: ['contract-docs-drift'],
+              assignees: ['roxdanila'],
+            });
+            core.info(`Opened issue #${created.data.number}`);
+
+      - name: Close the tracking issue when the drift is resolved
+        if: steps.check.outputs.exit_code == '0' && github.event_name != 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const existing = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'contract-docs-drift',
+            });
+            for (const issue of existing.data) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                body: 'The contract reference now matches the deployed contracts. Closing.',
+              });
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                state: 'closed',
+              });
+            }
+
+      - name: Report the result
+        if: always()
+        env:
+          EXIT_CODE: ${{ steps.check.outputs.exit_code }}
+        run: exit "$EXIT_CODE"

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,11 +26,19 @@
       "devDependencies": {
         "@docusaurus/module-type-aliases": "^3.7.0",
         "@docusaurus/types": "^3.7.0",
-        "@nexusmutual/deployments": "^3.4.0"
+        "@nexusmutual/deployments": "^3.4.0",
+        "ethers": "^6.17.0"
       },
       "engines": {
         "node": ">=22.14"
       }
+    },
+    "node_modules/@adraffy/ens-normalize": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.11.1.tgz",
+      "integrity": "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@algolia/cache-browser-local-storage": {
       "version": "4.24.0",
@@ -4704,6 +4712,32 @@
       "dev": true,
       "license": "GPL-3.0"
     },
+    "node_modules/@noble/curves": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
+      "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.3.2"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
+      "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@node-rs/jieba": {
       "version": "1.10.4",
       "resolved": "https://registry.npmjs.org/@node-rs/jieba/-/jieba-1.10.4.tgz",
@@ -6296,6 +6330,13 @@
       "engines": {
         "node": ">= 10.0.0"
       }
+    },
+    "node_modules/aes-js": {
+      "version": "4.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
+      "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/aggregate-error": {
       "version": "3.1.0",
@@ -9477,6 +9518,81 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/ethers": {
+      "version": "6.17.0",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.17.0.tgz",
+      "integrity": "sha512-BpyrpIPJ3ydEVow8zGaz1DuPS7YU8DcWxuBnY9a0UA/lvAPwrMr+EPXsfrul628SRaekPNeIM4UFh/91GWZang==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/ethers-io/"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@adraffy/ens-normalize": "1.11.1",
+        "@noble/curves": "1.2.0",
+        "@noble/hashes": "1.3.2",
+        "@types/node": "22.7.5",
+        "aes-js": "4.0.0-beta.5",
+        "tslib": "2.7.0",
+        "ws": "8.21.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/ethers/node_modules/@types/node": {
+      "version": "22.7.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.5.tgz",
+      "integrity": "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.19.2"
+      }
+    },
+    "node_modules/ethers/node_modules/tslib": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/ethers/node_modules/undici-types": {
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ethers/node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/eval": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,8 @@
       },
       "devDependencies": {
         "@docusaurus/module-type-aliases": "^3.7.0",
-        "@docusaurus/types": "^3.7.0"
+        "@docusaurus/types": "^3.7.0",
+        "@nexusmutual/deployments": "^3.4.0"
       },
       "engines": {
         "node": ">=22.14"
@@ -4695,6 +4696,13 @@
         "@emnapi/runtime": "^1.3.1",
         "@tybys/wasm-util": "^0.9.0"
       }
+    },
+    "node_modules/@nexusmutual/deployments": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@nexusmutual/deployments/-/deployments-3.4.0.tgz",
+      "integrity": "sha512-WvyRTPAbz53Y2O7cjkf1Uiqv7M6SH/EjdFrftOAr4t7r8A4iWe6pJDXJwD4YVDkSY/3mQIuWlc5MuXoKVfeCqA==",
+      "dev": true,
+      "license": "GPL-3.0"
     },
     "node_modules/@node-rs/jieba": {
       "version": "1.10.4",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
   "devDependencies": {
     "@docusaurus/module-type-aliases": "^3.7.0",
     "@docusaurus/types": "^3.7.0",
-    "@nexusmutual/deployments": "^3.4.0"
+    "@nexusmutual/deployments": "^3.4.0",
+    "ethers": "^6.17.0"
   },
   "browserslist": {
     "production": [

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "clear": "docusaurus clear",
     "serve": "docusaurus serve",
     "write-translations": "docusaurus write-translations",
-    "write-heading-ids": "docusaurus write-heading-ids"
+    "write-heading-ids": "docusaurus write-heading-ids",
+    "check:contract-docs": "node scripts/check-contract-docs.mjs"
   },
   "dependencies": {
     "@docusaurus/core": "^3.7.0",
@@ -31,7 +32,8 @@
   },
   "devDependencies": {
     "@docusaurus/module-type-aliases": "^3.7.0",
-    "@docusaurus/types": "^3.7.0"
+    "@docusaurus/types": "^3.7.0",
+    "@nexusmutual/deployments": "^3.4.0"
   },
   "browserslist": {
     "production": [

--- a/scripts/check-contract-docs.mjs
+++ b/scripts/check-contract-docs.mjs
@@ -1,0 +1,86 @@
+#!/usr/bin/env node
+/**
+ * Checks the contract reference docs against the deployed contracts.
+ *
+ * Two checks:
+ *   1. every solidity function documented in docs/developers/contracts/*.md
+ *      exists on the deployed ABI of the contract that page documents
+ *   2. every page maps to a contract that is actually deployed
+ *
+ * Resolves the deployed set from @nexusmutual/deployments at its latest
+ * published version, so drift shows up when contracts ship rather than
+ * when someone next edits the docs.
+ *
+ * Exits non-zero when drift is found. Intended to report, not to block.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const DOCS = path.join(ROOT, 'docs/developers/contracts');
+
+// doc file -> deployed contract name
+const PAGES = {
+  'Assessments.md': 'Assessments',
+  'Claims.md': 'Claims',
+  'Cover.md': 'Cover',
+  'Pool.md': 'Pool',
+  'Ramm.md': 'Ramm',
+  'StakingPool.md': 'StakingPool',
+  'StakingPoolFactory.md': 'StakingPoolFactory',
+  'StakingProducts.md': 'StakingProducts',
+  'TokenController.md': 'TokenController',
+};
+
+const { addresses, abis } = await import('@nexusmutual/deployments');
+
+const documentedFunctions = file =>
+  [...new Set(
+    [...fs.readFileSync(path.join(DOCS, file), 'utf8')
+      .matchAll(/^\s*function\s+([A-Za-z0-9_]+)\s*\(/gm)].map(m => m[1]),
+  )];
+
+const abiFunctions = name =>
+  new Set((abis[name] ?? []).filter(e => e.type === 'function').map(e => e.name));
+
+const problems = [];
+const rows = [];
+
+for (const [file, contract] of Object.entries(PAGES)) {
+  if (!fs.existsSync(path.join(DOCS, file))) {
+    problems.push(`${file}: page is missing`);
+    continue;
+  }
+  if (!abis[contract]) {
+    problems.push(`${file}: ${contract} has no published ABI — is it still deployed?`);
+    continue;
+  }
+
+  const documented = documentedFunctions(file);
+  const live = abiFunctions(contract);
+  const missing = documented.filter(fn => !live.has(fn));
+
+  rows.push({ file, contract, documented: documented.length, missing: missing.length });
+  if (missing.length) {
+    problems.push(`${file} (${contract}): not on the deployed ABI — ${missing.join(', ')}`);
+  }
+}
+
+const width = Math.max(...rows.map(r => r.file.length));
+for (const r of rows) {
+  const status = r.missing ? 'FAIL' : 'ok  ';
+  console.log(`${status} ${r.file.padEnd(width)}  ${r.contract.padEnd(20)} documented:${String(r.documented).padStart(3)}  notOnABI:${String(r.missing).padStart(3)}`);
+}
+
+console.log(`\ndeployed contracts: ${Object.keys(addresses).length}   published ABIs: ${Object.keys(abis).length}`);
+
+if (problems.length) {
+  console.log(`\n${problems.length} problem(s):`);
+  problems.forEach(p => console.log(`  - ${p}`));
+  console.log('\nThe contract reference has drifted from the deployed contracts.');
+  process.exit(1);
+}
+
+console.log('\nContract reference matches the deployed contracts.');

--- a/scripts/check-contract-docs.mjs
+++ b/scripts/check-contract-docs.mjs
@@ -2,14 +2,21 @@
 /**
  * Checks the contract reference docs against the deployed contracts.
  *
- * Two checks:
+ * Three checks:
  *   1. every solidity function documented in docs/developers/contracts/*.md
  *      exists on the deployed ABI of the contract that page documents
  *   2. every page maps to a contract that is actually deployed
+ *   3. every solidity constant quoted in those pages still holds the value
+ *      the deployed contract returns
  *
  * Resolves the deployed set from @nexusmutual/deployments at its latest
  * published version, so drift shows up when contracts ship rather than
  * when someone next edits the docs.
+ *
+ * Constant values live in the deployed bytecode, so check 3 reads them over
+ * JSON-RPC. Set ETH_RPC_URL to use your own endpoint. A network failure is
+ * reported but does not count as drift, so a flaky endpoint cannot raise a
+ * false alarm.
  *
  * Exits non-zero when drift is found. Intended to report, not to block.
  */
@@ -17,9 +24,11 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { ethers } from 'ethers';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const DOCS = path.join(ROOT, 'docs/developers/contracts');
+const RPC = process.env.ETH_RPC_URL || 'https://ethereum-rpc.publicnode.com';
 
 // doc file -> deployed contract name
 const PAGES = {
@@ -36,17 +45,45 @@ const PAGES = {
 
 const { addresses, abis } = await import('@nexusmutual/deployments');
 
-const documentedFunctions = file =>
-  [...new Set(
-    [...fs.readFileSync(path.join(DOCS, file), 'utf8')
-      .matchAll(/^\s*function\s+([A-Za-z0-9_]+)\s*\(/gm)].map(m => m[1]),
-  )];
+const read = file => fs.readFileSync(path.join(DOCS, file), 'utf8');
 
-const abiFunctions = name =>
-  new Set((abis[name] ?? []).filter(e => e.type === 'function').map(e => e.name));
+const documentedFunctions = txt =>
+  [...new Set([...txt.matchAll(/^\s*function\s+([A-Za-z0-9_]+)\s*\(/gm)].map(m => m[1]))];
+
+const documentedConstants = txt =>
+  [...txt.matchAll(/constant\s+([A-Z][A-Z0-9_]+)\s*=\s*([^;]+);/g)]
+    .map(m => ({ name: m[1], raw: m[2].trim() }));
+
+/** Resolve the simple literal forms the docs use. Returns null when unsupported. */
+const literal = raw => {
+  const s = raw.replace(/_/g, '').trim();
+  if (/^\d+$/.test(s)) return BigInt(s);
+  const ether = s.match(/^([\d.]+)\s*ether$/);
+  if (ether) return ethers.parseEther(ether[1]);
+  const days = s.match(/^(\d+)\s*days?$/);
+  if (days) return BigInt(days[1]) * 86400n;
+  const hours = s.match(/^(\d+)\s*hours?$/);
+  if (hours) return BigInt(hours[1]) * 3600n;
+  return null;
+};
+
+/**
+ * Contracts exposing NAME as a zero-arg view/pure getter at a known address.
+ * StakingPool is excluded by the address requirement: pools are deployed per
+ * pool through the factory, so there is no single address to read from.
+ */
+const gettersFor = name =>
+  Object.entries(abis)
+    .filter(([c, abi]) => addresses[c] && abi.some(e =>
+      e.type === 'function' && e.name === name && e.inputs.length === 0
+      && ['view', 'pure'].includes(e.stateMutability)))
+    .map(([c]) => c);
 
 const problems = [];
+const notes = [];
 const rows = [];
+
+// ---- checks 1 and 2 -------------------------------------------------------
 
 for (const [file, contract] of Object.entries(PAGES)) {
   if (!fs.existsSync(path.join(DOCS, file))) {
@@ -58,8 +95,8 @@ for (const [file, contract] of Object.entries(PAGES)) {
     continue;
   }
 
-  const documented = documentedFunctions(file);
-  const live = abiFunctions(contract);
+  const documented = documentedFunctions(read(file));
+  const live = new Set(abis[contract].filter(e => e.type === 'function').map(e => e.name));
   const missing = documented.filter(fn => !live.has(fn));
 
   rows.push({ file, contract, documented: documented.length, missing: missing.length });
@@ -70,11 +107,58 @@ for (const [file, contract] of Object.entries(PAGES)) {
 
 const width = Math.max(...rows.map(r => r.file.length));
 for (const r of rows) {
-  const status = r.missing ? 'FAIL' : 'ok  ';
-  console.log(`${status} ${r.file.padEnd(width)}  ${r.contract.padEnd(20)} documented:${String(r.documented).padStart(3)}  notOnABI:${String(r.missing).padStart(3)}`);
+  console.log(`${r.missing ? 'FAIL' : 'ok  '} ${r.file.padEnd(width)}  ${r.contract.padEnd(20)} documented:${String(r.documented).padStart(3)}  notOnABI:${String(r.missing).padStart(3)}`);
 }
 
-console.log(`\ndeployed contracts: ${Object.keys(addresses).length}   published ABIs: ${Object.keys(abis).length}`);
+// ---- check 3 --------------------------------------------------------------
+
+const provider = new ethers.JsonRpcProvider(RPC);
+let verified = 0;
+
+console.log('\nConstants quoted in the reference:');
+
+for (const [file, pageContract] of Object.entries(PAGES)) {
+  if (!fs.existsSync(path.join(DOCS, file))) continue;
+
+  for (const c of documentedConstants(read(file))) {
+    const expected = literal(c.raw);
+    if (expected === null) {
+      notes.push(`${file}: ${c.name} = ${c.raw} — value form not checked`);
+      continue;
+    }
+
+    const candidates = gettersFor(c.name);
+    const contract = candidates.includes(pageContract) ? pageContract : candidates[0];
+    if (!contract) {
+      notes.push(`${file}: ${c.name} has no public getter — not checked`);
+      continue;
+    }
+
+    let actual;
+    try {
+      const instance = new ethers.Contract(addresses[contract], abis[contract], provider);
+      actual = await instance[c.name]();
+    } catch (err) {
+      notes.push(`${file}: ${c.name} could not be read from ${contract} — ${(err.shortMessage || err.message).slice(0, 60)}`);
+      continue;
+    }
+
+    verified++;
+    if (BigInt(actual) === expected) {
+      console.log(`  ok    ${c.name.padEnd(26)} ${String(expected).padStart(22)}  (${contract})`);
+    } else {
+      console.log(`  FAIL  ${c.name.padEnd(26)} ${String(expected).padStart(22)}  documented, ${actual} onchain  (${contract})`);
+      problems.push(`${file}: ${c.name} is documented as ${c.raw} but ${contract} returns ${actual}`);
+    }
+  }
+}
+
+console.log(`\ndeployed contracts: ${Object.keys(addresses).length}   published ABIs: ${Object.keys(abis).length}   constants verified: ${verified}`);
+
+if (notes.length) {
+  console.log('\nNot checked:');
+  notes.forEach(n => console.log(`  - ${n}`));
+}
 
 if (problems.length) {
   console.log(`\n${problems.length} problem(s):`);


### PR DESCRIPTION
Adds a check that asserts the contract reference matches the deployed contracts.

> Based on #123 so it lands green. Retarget to `master` once that merges.

## Why

The contract reference had drifted to the point of documenting **25 functions that exist on no deployed ABI**, including two contracts that are not deployed at all. Nothing in the repo checks the docs against the contracts, so it was only found by a manual audit.

The drift originates in `smart-contracts`, not here. A check that only fires on docs PRs watches the wrong repo, so this also runs weekly.

## What it does

Reads `@nexusmutual/deployments` and asserts that every solidity function documented in `docs/developers/contracts/*.md` exists on the deployed ABI of the contract that page documents, and that each page maps to a contract that is actually deployed.

```
npm run check:contract-docs
```

## Design choices

**Resolves the latest published deployments**, not the pinned range. A pinned version only re-checks when someone bumps the dependency, which would have caught this drift once and then gone quiet on the next release. The cost is that a PR can start reporting drift because a package was published, with no change to the docs — which for a reporting check is the point.

**Reports, does not gate.** Please keep it out of the required status checks: a contract release should not block unrelated documentation work.

**Weekly on Mondays.** Deployments publishes roughly every one to three months, so weekly is ample and keeps the signal quiet.

**A single tracking issue.** Drift found on a scheduled run opens one issue labelled `contract-docs-drift` assigned to @roxdanila, and updates that same issue on later runs rather than opening another. It is closed automatically once the reference matches again. This repo already carries several unattended automated PRs, so the check is deliberately built to never accumulate.

## Verification

Run against this branch it reports clean. Run against `master` it reports the 25 functions that #123 fixes, so the check demonstrably catches the drift it was written for.