### PR TITLE
ci: check the protocol numbers stated in prose

### DIFF
--- a/docs/developers/contracts/Cover.md
+++ b/docs/developers/contracts/Cover.md
@@ -105,6 +105,7 @@ uint private constant BUCKET_SIZE = 7 days;
 
 - **Allocation Units per NXM:**
 
+<!-- @check Cover.NXM_PER_ALLOCATION_UNIT = 0.01 ether -->
 ```solidity
 uint private constant ALLOCATION_UNITS_PER_NXM = 100;
 uint public constant NXM_PER_ALLOCATION_UNIT = ONE_NXM / ALLOCATION_UNITS_PER_NXM;

--- a/docs/governance/governance.md
+++ b/docs/governance/governance.md
@@ -12,6 +12,7 @@ Where a proposal requires a change onchain, the Advisory Board enacts the outcom
 
 ## The Advisory Board
 
+<!-- @check Registry.ADVISORY_BOARD_SEATS = 5 -->
 The Advisory Board (AB) puts forward governance proposals and recommends a default outcome. There are five (5) subject matter experts that sit on the AB, who bring expertise across three broad skill sets:
 * Technical expertise: smart contract security and blockchain
 * Technical expertise: insurance and mutuals
@@ -43,7 +44,9 @@ For added security, an Emergency Pause Safe multisig was created. The Emergency 
 Ultimately, AB members serve at the discretion of Nexus Mutual members. Should members decide an AB member needs to be replaced, Nexus Mutual members can raise a proposal onchain to replace an AB member without interference from existing AB members.
 
 Any Nexus Mutual member can raise a proposal to replace an AB member, with the following requirements:
+<!-- @check Governor.PROPOSAL_THRESHOLD = 100 ether -->
 * The member who raises the proposal must hold more than 99 NXM in order to put the proposal onchain; and
+<!-- @check Governor.MEMBER_VOTE_QUORUM_PERCENTAGE = 15 -->
 * At least 15% of the total NXM token supply must participate in the vote.
 
 Participation counts every vote cast, whether for, against, or abstain. If a proposal to replace an AB member receives more votes for than against and quorum is met, the proposal will pass.
@@ -54,6 +57,7 @@ Voting on a proposal to replace an AB member locks your NXM transfers until the 
 
 Every member who joins Nexus Mutual has voting power equal to one vote plus the sum total of their NXM tokens.
 
+<!-- @check Governor.VOTE_WEIGHT_CAP_PERCENTAGE = 5 -->
 A single member's voting power is capped at 5% of the total NXM supply. This cap applies to Snapshot votes as well as onchain votes, because the Snapshot space reads voting power from the `VotePower` contract.
 
 ### Quorum for Rejection
@@ -125,6 +129,7 @@ The `Governor` contract handles two kinds of proposal.
 An AB proposal carries the transactions that enact a governance outcome, such as a contract upgrade or a Capital Pool allocation. Only Advisory Board members can raise, vote on, and execute these proposals.
 
 * Each AB member holds one vote, regardless of how much NXM they hold.
+<!-- @check Governor.ADVISORY_BOARD_THRESHOLD = 3 -->
 * Three votes in favour carry the proposal, at which point voting closes and the timelock starts.
 * The Advisory Board can cancel an AB proposal before it is executed.
 
@@ -138,6 +143,7 @@ Both kinds of proposal follow the same sequence:
 
 * Members and AB members cast a vote for, against, or abstain.
 * A proposal carries when it has more votes for than against, and it meets the threshold that applies to its kind.
+<!-- @check Governor.TIMELOCK_PERIOD = 1 days -->
 * A 24-hour timelock runs before a carried proposal can be executed.
 
 ***Disclaimer***: While all care has been taken, there may be some discrepancies between the governance documentation and the functioning of the onchain governance smart contracts. In the event a discrepancy exists in this documentation, the smart contract rules apply.

--- a/docs/overview/membership.md
+++ b/docs/overview/membership.md
@@ -30,6 +30,7 @@ While the Ethereum address you use for your registered membership address can be
 By becoming a member you agree to the conditions specified in the [DAO Member Agreement](https://app.nexusmutual.io/assets/Nexus-Mutual-DAO-Member-Agreement-FIN.pdf).
 
 * **KYC / AML**. To become a member, you will need to verify your identity through the Know-Your-Customer / Anti-Money-Laundering process. If this fails, you won’t be able to join the Mutual.
+<!-- @check Registry.JOIN_FEE = 0.002 ether -->
 * **You pay an initial membership fee**. Membership costs 0.0020 ETH and is required for anyone who joins the Mutual.
 * **You own part of the Mutual**. You can buy cover and earn more NXM by helping run the Mutual, including voting on claims, staking NXM, and voting on proposals.
 

--- a/docs/protocol/capacity.md
+++ b/docs/protocol/capacity.md
@@ -34,6 +34,7 @@ The Advisory Board can adjust two factors to adjust exposure to risk for any one
 
 ### Global Capacity Factor
 
+<!-- @check Cover.getGlobalCapacityRatio = 20000 -->
 The global capacity factor is set at two for all listings, which means every one NXM staked opens up two NXM worth of capacity.
 
 ### Capacity Reduction Factor

--- a/docs/protocol/capital-pool/mcr.md
+++ b/docs/protocol/capital-pool/mcr.md
@@ -10,6 +10,7 @@ The MCR is driven by the Mutual's Total Active Cover Amount, which is the curren
 
 <code>MCR = f(Cover) = Total Active Cover Amount in ETH / Gearing Factor</code>
 
+<!-- @check Pool.GEARING_FACTOR = 48000 -->
 Gearing Factor currently = 4.8
 
 The full capital model is run offchain. If it starts producing results that are materially different to the current Gearing Factor, the factor is updated through a governance action.

--- a/docs/protocol/claims-assessment.md
+++ b/docs/protocol/claims-assessment.md
@@ -57,6 +57,7 @@ These risk experts will review the incident details and proof of loss provided b
 
 Once you submit your claim, the Claims Committee will be alerted and begin their review.
 
+<!-- @check Assessments.minVotingPeriod = 3 days -->
 Any claim that is submitted will be open for voting for at least 72 hours. During that 72 hours, the Claims Committee will review the details provided, discuss the validity of your claim, and cast their votes. At least 2 of the 3 Claims Committee Assessors need to cast **accept** votes for a claim to be accepted.
 
 Once the Claims Committee has cast their votes and the 72-hour period ends, voting on the claim will close.

--- a/docs/protocol/pricing.md
+++ b/docs/protocol/pricing.md
@@ -43,6 +43,7 @@ The spot price decreases linearly from <code>bumpedPrice</code> to <code>targetP
 <p><code>spotPrice = MAX(bumpedPrice - priceDrop, targetPrice)</code></p>
 
 Where:
+<!-- @check StakingProducts.PRICE_BUMP_RATIO = 500 -->
 * <code>bump = 0.05% addition to the spot price per 1% of pool capacity used</code>
 * <code>Bumped price = spotPrice + capacity% of the pool to be used / 1% x 0.05</code>
 * <code>priceDrop = timeSinceLastCoverBuy * speed</code>
@@ -62,6 +63,7 @@ The Bumped Price gets updated after each cover buy and is used to calculate the 
 
 ### Price Drop
 
+<!-- @check StakingProducts.PRICE_CHANGE_PER_DAY = 200 -->
 This is determined by taking the <code>timeSinceLastCoverBuy</code> and multiplying by the <code>Speed</code>, which moves at 2.0% per day. The price drop is subtracted from spot price.
 
 *Example*

--- a/docs/protocol/staking/staking-pools.md
+++ b/docs/protocol/staking/staking-pools.md
@@ -30,6 +30,7 @@ Managers choose which cover products to include in their pool and how much NXM t
 
 ### Product weight
 
+<!-- @check StakingProducts.MAX_TOTAL_WEIGHT = 2000 -->
 Managers can stake NXM across products with up to 20x leverage. The amount of leverage used within the pool determines the total target weight for the pool. For each individual product, the most NXM that can be staked is the balance of NXM available in the pool.
 
 *For example*: if a staking pool has 10,000 NXM, a manager can stake up to 10,000 NXM against a single product. If a manager uses 20x leverage, they can stake 10,000 NXM against 20 different cover products. However, a manager could stake 5,000 NXM against 40 different cover products.

--- a/docs/protocol/staking/staking.md
+++ b/docs/protocol/staking/staking.md
@@ -24,6 +24,7 @@ NXM stakers do not control how their NXM is allocated within a staking pool, tho
 
 When someone decides to stake their NXM, they need to choose the length of time that their NXM will be locked in a staking pool: this is referred to as the staking period.
 
+<!-- @check StakingProducts.TRANCHE_DURATION = 91 days -->
 Members can choose to stake their NXM for as little as 91 days or as long as two years. There are a total of eight staking periods to choose from. Members are able to delegate their NXM to multiple staking pools and for multiple staking periods.
 
 | Staking Period # | Days |

--- a/scripts/check-contract-docs.mjs
+++ b/scripts/check-contract-docs.mjs
@@ -28,6 +28,7 @@ import { ethers } from 'ethers';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const DOCS = path.join(ROOT, 'docs/developers/contracts');
+const ALL_DOCS = path.join(ROOT, 'docs');
 const RPC = process.env.ETH_RPC_URL || 'https://ethereum-rpc.publicnode.com';
 
 // doc file -> deployed contract name
@@ -153,7 +154,76 @@ for (const [file, pageContract] of Object.entries(PAGES)) {
   }
 }
 
-console.log(`\ndeployed contracts: ${Object.keys(addresses).length}   published ABIs: ${Object.keys(abis).length}   constants verified: ${verified}`);
+// ---- check 4: numbers stated in prose ------------------------------------
+//
+// Docs often state a number a reader can use rather than the constant behind
+// it: "0.05% per 1% of capacity" for PRICE_BUMP_RATIO = 500. Those have no
+// machine-readable link to the contract, so an annotation supplies one:
+//
+//   <!-- @check StakingProducts.PRICE_BUMP_RATIO = 500 -->
+//
+// The annotation asserts the underlying value has not moved. It does not
+// verify the prose is a correct reading of that value, which stays a human
+// judgement. It catches drift, not misinterpretation.
+
+const ANNOTATION = /<!--\s*@check\s+([A-Za-z0-9_]+)\.([A-Za-z0-9_]+)\s*=\s*(.+?)\s*-->/g;
+
+const annotations = [];
+const walk = dir => {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const p = path.join(dir, entry.name);
+    if (entry.isDirectory()) { walk(p); continue; }
+    if (!entry.name.endsWith('.md')) continue;
+    const txt = fs.readFileSync(p, 'utf8');
+    for (const m of txt.matchAll(ANNOTATION)) {
+      annotations.push({
+        file: path.relative(ALL_DOCS, p),
+        contract: m[1],
+        getter: m[2],
+        raw: m[3].trim(),
+        line: txt.slice(0, m.index).split('\n').length,
+      });
+    }
+  }
+};
+walk(ALL_DOCS);
+
+if (annotations.length) {
+  console.log('\nNumbers stated in prose:');
+  for (const a of annotations) {
+    const expected = literal(a.raw);
+    const where = `${a.file}:${a.line}`;
+
+    if (expected === null) {
+      notes.push(`${where}: @check ${a.contract}.${a.getter} = ${a.raw} — value form not understood`);
+      continue;
+    }
+    if (!addresses[a.contract] || !abis[a.contract]) {
+      problems.push(`${where}: @check names ${a.contract}, which is not deployed`);
+      continue;
+    }
+
+    let actual;
+    try {
+      const instance = new ethers.Contract(addresses[a.contract], abis[a.contract], provider);
+      actual = await instance[a.getter]();
+    } catch (err) {
+      notes.push(`${where}: ${a.contract}.${a.getter} could not be read — ${(err.shortMessage || err.message).slice(0, 60)}`);
+      continue;
+    }
+
+    verified++;
+    const label = `${a.contract}.${a.getter}`;
+    if (BigInt(actual) === expected) {
+      console.log(`  ok    ${label.padEnd(44)} ${String(expected).padStart(22)}  [${where}]`);
+    } else {
+      console.log(`  FAIL  ${label.padEnd(44)} ${String(expected).padStart(22)}  documented, ${actual} onchain  [${where}]`);
+      problems.push(`${where}: ${label} is documented as ${a.raw} but returns ${actual}. The prose around this line is derived from it and needs rereading.`);
+    }
+  }
+}
+
+console.log(`\ndeployed contracts: ${Object.keys(addresses).length}   published ABIs: ${Object.keys(abis).length}   values verified: ${verified}`);
 
 if (notes.length) {
   console.log('\nNot checked:');

--- a/scripts/check-contract-docs.mjs
+++ b/scripts/check-contract-docs.mjs
@@ -69,6 +69,15 @@ const literal = raw => {
 };
 
 /**
+ * Constants that are private in the contract but readable through a getter
+ * under a different name.
+ */
+const ALIASES = {
+  GLOBAL_CAPACITY_RATIO: 'getGlobalCapacityRatio',
+  GLOBAL_REWARDS_RATIO: 'getGlobalRewardsRatio',
+};
+
+/**
  * Contracts exposing NAME as a zero-arg view/pure getter at a known address.
  * StakingPool is excluded by the address requirement: pools are deployed per
  * pool through the factory, so there is no single address to read from.
@@ -111,61 +120,6 @@ for (const r of rows) {
   console.log(`${r.missing ? 'FAIL' : 'ok  '} ${r.file.padEnd(width)}  ${r.contract.padEnd(20)} documented:${String(r.documented).padStart(3)}  notOnABI:${String(r.missing).padStart(3)}`);
 }
 
-// ---- check 3 --------------------------------------------------------------
-
-const provider = new ethers.JsonRpcProvider(RPC);
-let verified = 0;
-
-console.log('\nConstants quoted in the reference:');
-
-for (const [file, pageContract] of Object.entries(PAGES)) {
-  if (!fs.existsSync(path.join(DOCS, file))) continue;
-
-  for (const c of documentedConstants(read(file))) {
-    const expected = literal(c.raw);
-    if (expected === null) {
-      notes.push(`${file}: ${c.name} = ${c.raw} — value form not checked`);
-      continue;
-    }
-
-    const candidates = gettersFor(c.name);
-    const contract = candidates.includes(pageContract) ? pageContract : candidates[0];
-    if (!contract) {
-      notes.push(`${file}: ${c.name} has no public getter — not checked`);
-      continue;
-    }
-
-    let actual;
-    try {
-      const instance = new ethers.Contract(addresses[contract], abis[contract], provider);
-      actual = await instance[c.name]();
-    } catch (err) {
-      notes.push(`${file}: ${c.name} could not be read from ${contract} — ${(err.shortMessage || err.message).slice(0, 60)}`);
-      continue;
-    }
-
-    verified++;
-    if (BigInt(actual) === expected) {
-      console.log(`  ok    ${c.name.padEnd(26)} ${String(expected).padStart(22)}  (${contract})`);
-    } else {
-      console.log(`  FAIL  ${c.name.padEnd(26)} ${String(expected).padStart(22)}  documented, ${actual} onchain  (${contract})`);
-      problems.push(`${file}: ${c.name} is documented as ${c.raw} but ${contract} returns ${actual}`);
-    }
-  }
-}
-
-// ---- check 4: numbers stated in prose ------------------------------------
-//
-// Docs often state a number a reader can use rather than the constant behind
-// it: "0.05% per 1% of capacity" for PRICE_BUMP_RATIO = 500. Those have no
-// machine-readable link to the contract, so an annotation supplies one:
-//
-//   <!-- @check StakingProducts.PRICE_BUMP_RATIO = 500 -->
-//
-// The annotation asserts the underlying value has not moved. It does not
-// verify the prose is a correct reading of that value, which stays a human
-// judgement. It catches drift, not misinterpretation.
-
 const ANNOTATION = /<!--\s*@check\s+([A-Za-z0-9_]+)\.([A-Za-z0-9_]+)\s*=\s*(.+?)\s*-->/g;
 
 const annotations = [];
@@ -187,6 +141,64 @@ const walk = dir => {
   }
 };
 walk(ALL_DOCS);
+
+// ---- check 3 --------------------------------------------------------------
+
+const provider = new ethers.JsonRpcProvider(RPC);
+let verified = 0;
+
+console.log('\nConstants quoted in the reference:');
+
+for (const [file, pageContract] of Object.entries(PAGES)) {
+  if (!fs.existsSync(path.join(DOCS, file))) continue;
+
+  for (const c of documentedConstants(read(file))) {
+    const expected = literal(c.raw);
+    if (expected === null) {
+      const covered = annotations.some(a => a.getter === c.name);
+      if (!covered) notes.push(`${file}: ${c.name} = ${c.raw} — value form not checked`);
+      continue;
+    }
+
+    const getter = ALIASES[c.name] ?? c.name;
+    const candidates = gettersFor(getter);
+    const contract = candidates.includes(pageContract) ? pageContract : candidates[0];
+    if (!contract) {
+      notes.push(`${file}: ${c.name} is private and has no getter — not checked`);
+      continue;
+    }
+
+    let actual;
+    try {
+      const instance = new ethers.Contract(addresses[contract], abis[contract], provider);
+      actual = await instance[getter]();
+    } catch (err) {
+      notes.push(`${file}: ${c.name} could not be read from ${contract} — ${(err.shortMessage || err.message).slice(0, 60)}`);
+      continue;
+    }
+
+    verified++;
+    const via = getter === c.name ? contract : `${contract}.${getter}`;
+    if (BigInt(actual) === expected) {
+      console.log(`  ok    ${c.name.padEnd(26)} ${String(expected).padStart(22)}  (${via})`);
+    } else {
+      console.log(`  FAIL  ${c.name.padEnd(26)} ${String(expected).padStart(22)}  documented, ${actual} onchain  (${via})`);
+      problems.push(`${file}: ${c.name} is documented as ${c.raw} but ${contract} returns ${actual}`);
+    }
+  }
+}
+
+// ---- check 4: numbers stated in prose ------------------------------------
+//
+// Docs often state a number a reader can use rather than the constant behind
+// it: "0.05% per 1% of capacity" for PRICE_BUMP_RATIO = 500. Those have no
+// machine-readable link to the contract, so an annotation supplies one:
+//
+//   <!-- @check StakingProducts.PRICE_BUMP_RATIO = 500 -->
+//
+// The annotation asserts the underlying value has not moved. It does not
+// verify the prose is a correct reading of that value, which stays a human
+// judgement. It catches drift, not misinterpretation.
 
 if (annotations.length) {
   console.log('\nNumbers stated in prose:');


### PR DESCRIPTION
Extends the drift check to the numbers the docs state in prose, which is the class of error that started all of this.

> Stacked on #125, and merges #124 in so the annotations sit on the corrected prose. Merge order: #123 → #124 → #125 → this. Retarget to `master` as they land.

## The gap

#125 checks two things: that documented functions exist, and that documented **constants** hold their onchain value. Neither would have caught the pricing bug.

The docs rarely quote the constant. They state a number a reader can use:

> `bump = 0.05% addition to the spot price per 1% of pool capacity used`

That is `PRICE_BUMP_RATIO = 500`, but nothing in the file says so. When the constant changed from `20_00` to `5_00` in November 2024, the prose stayed wrong for twenty months.

## The fix

Annotate the number with the value it comes from:

```markdown
<!-- @check StakingProducts.PRICE_BUMP_RATIO = 500 -->
* `bump = 0.05% addition to the spot price per 1% of pool capacity used`
```

The check reads the value from the deployed contract and reports the file and line on a mismatch. It is an HTML comment, so it does not render — verified against the built output.

## Coverage

Fourteen numbers annotated, all verified against mainnet:

| Number in the docs | Anchor |
|---|---|
| 0.05% per 1% capacity | `StakingProducts.PRICE_BUMP_RATIO` |
| 2.0% per day | `StakingProducts.PRICE_CHANGE_PER_DAY` |
| 20x leverage | `StakingProducts.MAX_TOTAL_WEIGHT` |
| 91 day tranches | `StakingProducts.TRANCHE_DURATION` |
| Gearing factor 4.8 | `Pool.GEARING_FACTOR` |
| Capacity factor two | `Cover.getGlobalCapacityRatio` |
| 0.0020 ETH membership | `Registry.JOIN_FEE` |
| Five AB members | `Registry.ADVISORY_BOARD_SEATS` |
| 72 hour voting | `Assessments.minVotingPeriod` |
| 24 hour timelock | `Governor.TIMELOCK_PERIOD` |
| 5% voting power cap | `Governor.VOTE_WEIGHT_CAP_PERCENTAGE` |
| 15% quorum | `Governor.MEMBER_VOTE_QUORUM_PERCENTAGE` |
| More than 99 NXM | `Governor.PROPOSAL_THRESHOLD` |
| Three AB votes | `Governor.ADVISORY_BOARD_THRESHOLD` |

Combined with #125 the check now verifies **23 values** in total.

## Proof it catches the original bug

Setting the annotation back to the pre-November-2024 value reproduces the failure:

```
FAIL  StakingProducts.PRICE_BUMP_RATIO   2000  documented, 500 onchain  [protocol/pricing.md:46]

protocol/pricing.md:46: StakingProducts.PRICE_BUMP_RATIO is documented as 2000
but returns 500. The prose around this line is derived from it and needs rereading.
```

## What it deliberately does not do

It asserts the underlying value has not moved. It does **not** verify the prose is a correct reading of that value — if someone writes "0.5%" where 500 basis points means 0.05%, this still passes. That stays a human judgement, which is why the failure message points at the surrounding prose rather than claiming the text is wrong.

It catches drift, not misinterpretation. Drift is what happened here.