### PR TITLE
ci: run the worked examples against the contracts

### DIFF
--- a/scripts/check-contract-docs.mjs
+++ b/scripts/check-contract-docs.mjs
@@ -235,6 +235,66 @@ if (annotations.length) {
   }
 }
 
+// ---- check 5: worked examples --------------------------------------------
+//
+// Annotations assert a constant has not moved. They cannot tell whether the
+// prose reads it correctly: "0.5%" where 500 basis points means 0.05% still
+// passes. Running the example removes that gap, because the number comes back
+// from the contract rather than from the sentence.
+
+const { examples } = await import('./doc-examples.mjs');
+
+/** Strings a reader might reasonably have written for this number. */
+const renderings = n => [...new Set([
+  String(n),
+  ...[1, 2].map(d => n.toFixed(d)).filter(s => Number(s) === n),
+])];
+
+const appearsIn = (text, n) => renderings(n).some(s => text.includes(s));
+
+if (examples.length) {
+  console.log('\nWorked examples:');
+
+  for (const ex of examples) {
+    const docPath = path.join(ALL_DOCS, ex.doc);
+    if (!fs.existsSync(docPath)) {
+      problems.push(`${ex.doc}: page is missing, cannot run "${ex.title}"`);
+      continue;
+    }
+    const text = fs.readFileSync(docPath, 'utf8');
+
+    let produced;
+    try {
+      const bound = Object.fromEntries(Object.keys(abis)
+        .filter(c => addresses[c])
+        .map(c => [c, new ethers.Contract(addresses[c], abis[c], provider)]));
+      produced = await ex.run(bound);
+    } catch (err) {
+      notes.push(`${ex.doc}: "${ex.title}" could not be run — ${(err.shortMessage || err.message).slice(0, 70)}`);
+      continue;
+    }
+
+    const checks = { ...(ex.inputs ?? {}), ...produced };
+    const missing = Object.entries(checks).filter(([, v]) => !appearsIn(text, v));
+
+    verified += Object.keys(checks).length;
+
+    if (missing.length === 0) {
+      const shown = Object.entries(produced).map(([k, v]) => `${k} ${v}`).join(', ');
+      console.log(`  ok    ${ex.title.padEnd(46)} ${shown}  [${ex.doc}]`);
+    } else {
+      console.log(`  FAIL  ${ex.title.padEnd(46)} [${ex.doc}]`);
+      for (const [label, value] of missing) {
+        console.log(`          ${label} is ${value} onchain, and does not appear in the page`);
+      }
+      problems.push(
+        `${ex.doc} (${ex.section ?? ex.title}): the example does not match the contract — `
+        + missing.map(([l, v]) => `${l} should be ${v}`).join('; '),
+      );
+    }
+  }
+}
+
 console.log(`\ndeployed contracts: ${Object.keys(addresses).length}   published ABIs: ${Object.keys(abis).length}   values verified: ${verified}`);
 
 if (notes.length) {

--- a/scripts/doc-examples.mjs
+++ b/scripts/doc-examples.mjs
@@ -1,0 +1,82 @@
+/**
+ * Worked examples from the docs, executed against the deployed contracts.
+ *
+ * A fixture encodes the inputs of an example and how to render its result.
+ * It never encodes the answer. The answer comes back from the contract, and
+ * the check asserts that number appears in the doc. A page therefore cannot
+ * state a figure the contract does not produce, which catches a misreading
+ * of a constant as well as a change to it.
+ *
+ * Inputs are asserted against the doc too, so a fixture cannot quietly drift
+ * away from the example it claims to check.
+ */
+
+/** Render a value held against TARGET_PRICE_DENOMINATOR as a percentage. */
+export const asPercent = raw => Number(raw) / 100;
+
+/** Render a duration in seconds as whole days. */
+export const asDays = raw => Number(raw) / 86400;
+
+export const examples = [
+  {
+    doc: 'protocol/pricing.md',
+    title: 'Bumped price after a cover buy',
+    section: 'Bumped price',
+    // The example states a spot price and the share of capacity being used.
+    inputs: {
+      'spot price (%)': 2.5,
+      'capacity used (%)': 15,
+    },
+    async run({ StakingProducts }) {
+      const T = 1800000000n;
+      const product = {
+        lastEffectiveWeight: 0,
+        targetWeight: 100,
+        targetPrice: 250n,           // 2.5%
+        bumpedPrice: 250n,           // 2.5%, the spot price above
+        bumpedPriceUpdateTime: T,
+      };
+      const [, updated] = await StakingProducts.calculatePremium(
+        product,
+        365n * 86400n,               // period
+        1500n,                       // cover amount, 15% of the capacity below
+        10000n,                      // total capacity in allocation units
+        250n,                        // target price
+        T,                           // no time has passed, so no price drop
+        10n ** 16n,                  // NXM per allocation unit
+        10000n,                      // TARGET_PRICE_DENOMINATOR
+      );
+      return { 'bumped price (%)': asPercent(updated.bumpedPrice) };
+    },
+  },
+
+  {
+    doc: 'protocol/pricing.md',
+    title: 'Price drop over three days',
+    section: 'Price Drop',
+    inputs: {
+      'days since the last cover buy': 3,
+    },
+    async run({ StakingProducts }) {
+      const T = 1800000000n;
+      // With a target price of zero the whole drop is visible.
+      const dropped = await StakingProducts.getBasePrice(650n, T, 0n, T + 3n * 86400n);
+      return { 'price drop (%)': asPercent(650n - dropped) };
+    },
+  },
+
+  {
+    doc: 'protocol/pricing.md',
+    title: 'Spot price falls back to the target price',
+    section: 'Calculating Spot Price',
+    inputs: {
+      'bumped price (%)': 6.5,
+      'target price (%)': 4,
+    },
+    async run({ StakingProducts }) {
+      const T = 1800000000n;
+      const base = await StakingProducts.getBasePrice(650n, T, 400n, T + 3n * 86400n);
+      return { 'spot price (%)': asPercent(base) };
+    },
+  },
+];


### PR DESCRIPTION
Closes the gap #126 leaves open: an annotation proves a constant has not moved, but not that the prose reads it correctly.

> Stacked on #126. Merge order: #123 → #124 → #125 → #126 → this.

## The gap

#126 asserts `PRICE_BUMP_RATIO = 500`. Documenting that as **0.5%** instead of **0.05%** passes, because the constant is unchanged. The annotation checks the input to the reasoning, never the reasoning.

## The fix

The pricing maths is exposed as `pure` functions, so a stated number can be recomputed from the contract rather than trusted.

A fixture in `scripts/doc-examples.mjs` encodes an example's **inputs** and how to render the result. It never encodes the answer — the answer comes back from the contract, and the check asserts that number appears in the page. A page cannot state a figure the contract does not produce. Inputs are asserted against the page too, so a fixture cannot drift from the example it claims to check.

## Coverage

Three examples from `protocol/pricing.md`, all reproducing against the deployed `StakingProducts`:

```
ok    Bumped price after a cover buy               bumped price (%) 3.25
ok    Price drop over three days                   price drop (%) 6
ok    Spot price falls back to the target price    spot price (%) 4
```

Total values verified across the whole check is now **34**.

## Proof it catches a misreading

Rewriting the docs to claim the bump is `0.5%` and the example result is `10`:

```
FAIL  Bumped price after a cover buy  [protocol/pricing.md]
        bumped price (%) is 3.25 onchain, and does not appear in the page

protocol/pricing.md (Bumped price): the example does not match the contract
— bumped price (%) should be 3.25
```

**The constant annotation passed in that run.** The constant had not moved; only the executed example caught it. That is the whole point of this PR.

It also independently confirms the second fix in #124 — `getBasePrice(6.5%, +3 days, target 4%)` returns exactly `4%`, which is what the corrected spot price example states. The original text said `3.0%`.

## Scope

Only reaches docs whose maths is callable. `StakingProducts` covers pricing; `Pool.calculateCurrentMCR` and the `Ramm` view functions would extend it to the MCR and RAMM pages, which is the natural follow-up. Prose with no function behind it — cover wordings, governance process, product descriptions — stays human-verified.