### PR TITLE
ci: build the site on pull requests and on master

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,45 @@
+name: Build
+
+# The site is built and deployed from master by an external integration, so a
+# change that breaks the install or the build is only discovered at deploy
+# time, after it has already merged. This runs the same two steps the deploy
+# runs, before the merge.
+#
+# Unlike the contract docs drift check, a failure here is this repository's
+# own and should block. Add it to the required status checks.
+
+on:
+  pull_request:
+    branches: [master]
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+# A newer push supersedes an in-flight run for the same ref.
+concurrency:
+  group: build-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .node-version
+          cache: npm
+
+      # npm ci fails when package.json and package-lock.json disagree, which
+      # is the failure a lockfile conflict resolved by hand tends to produce.
+      - name: Install
+        run: npm ci
+
+      # onBrokenLinks is set to throw, so this also fails on a broken internal
+      # link or anchor.
+      - name: Build
+        run: npm run build


### PR DESCRIPTION
Runs `npm ci` and `npm run build` before a merge, which nothing currently does.

> Independent of the docs stack (#123–#127) and based on `master`, so it can merge on its own.

## Why

The repository has **no workflows at all**, and the site is not on GitHub Pages — the Pages API returns 404, there is no `gh-pages` branch, and `docs.nexusmutual.io` is served by Cloudflare. So the deploy is an external integration building from `master`.

That means nothing verifies the install or the build before a change lands. A broken lockfile, or a broken internal link, is discovered when the deploy runs — after it is already on `master`, with the site as the thing that reports it.

## What it does

The same two steps the deploy runs:

- **`npm ci`** — fails when `package.json` and `package-lock.json` disagree, which is what a lockfile conflict resolved by hand tends to produce
- **`npm run build`** — `onBrokenLinks` is set to `throw`, so this also fails on a broken internal link or anchor

Node comes from `.node-version` (currently `22.14.0`) rather than a hardcoded version, so the workflow tracks what the repository already declares.

Runs on pull requests and on pushes to `master`, so a bad merge is caught even when the PR that produced it was stale. Concurrency is set to cancel superseded runs.

## Please make this a required status check

This differs from the drift check in #125 deliberately. That one reports without gating, because it fails for reasons originating in `smart-contracts` and should not block documentation work. A failure **here** is this repository's own and should stop the merge.

## Verification

Confirmed against a clean checkout of this branch, running the exact workflow steps:

```
npm ci    -> added 1486 packages
npm run build -> [SUCCESS] Generated static files in "build"
```

And confirmed it catches the failure it is for — adding a dependency to `package.json` without updating the lockfile:

```
npm error `npm ci` can only install packages when your package.json and
npm error package-lock.json are in sync.
npm error Missing: left-pad@1.3.0 from lock file
```

`master` is healthy today, so this lands green.