### PR TITLE
docs: rewrite the readme for this repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,41 +1,73 @@
-# Website
+# Nexus Mutual documentation
 
-This website is built using [Docusaurus 2](https://docusaurus.io/), a modern static website generator.
+The source of [docs.nexusmutual.io](https://docs.nexusmutual.io/) — the member and developer documentation for the Nexus Mutual protocol. Built with [Docusaurus](https://docusaurus.io/).
 
-### Installation
+## Running it locally
 
-```
-$ yarn
-```
+Node 22.14 (see `.node-version`) and npm.
 
-### Local Development
-
-```
-$ yarn start
+```bash
+npm install
+npm start
 ```
 
-This command starts a local development server and opens up a browser window. Most changes are reflected live without having to restart the server.
+`npm start` opens the site at `localhost:3000` and reloads as you edit. To check what actually ships, build it and serve the output:
 
-### Build
-
-```
-$ yarn build
-```
-
-This command generates static content into the `build` directory and can be served using any static contents hosting service.
-
-### Deployment
-
-Using SSH:
-
-```
-$ USE_SSH=true yarn deploy
+```bash
+npm run build
+npm run serve
 ```
 
-Not using SSH:
+The build fails on a broken internal link, so it catches more than `npm start` does. Run it before opening a pull request.
 
-```
-$ GIT_USER=<Your GitHub username> yarn deploy
+## Where the content lives
+
+Every page is a Markdown file under `docs/`:
+
+| Directory | What it covers |
+| --- | --- |
+| `overview/` | Membership, cover products, claims history |
+| `protocol/` | Cover, staking, pricing, capital pool, claim assessment |
+| `governance/` | How proposals work, the Advisory Board, the DAO |
+| `developers/` | Contract reference, integration guides, diagrams |
+| `rwi-vault/` | The Real-World Insurance Vault |
+| `resources/` | Audits, security, FAQ |
+
+The sidebar is generated from the directory tree. A new page needs `sidebar_position` in its frontmatter to sit in the right place, and a `_category_.json` gives a subdirectory its label.
+
+Diagrams are [Mermaid](https://mermaid.js.org/) in a `mermaid` fenced block and render natively.
+
+## Keeping the docs true to the contracts
+
+The contract reference and the protocol numbers are checked against the deployed contracts:
+
+```bash
+npm run check:contract-docs
 ```
 
-If you are using GitHub pages for hosting, this command is a convenient way to build the website and push to the `gh-pages` branch.
+It verifies three things:
+
+- every solidity function documented under `docs/developers/contracts/` exists on the deployed contract's ABI
+- every constant quoted there still holds the value the contract returns
+- the worked examples reproduce when run against the contract's own functions
+
+Numbers written in prose are tied to their source with an annotation, which does not render:
+
+```markdown
+<!-- @check StakingProducts.PRICE_BUMP_RATIO = 500 -->
+* bump = 0.05% addition to the spot price per 1% of pool capacity used
+```
+
+If you change a number that carries one of these, update the annotation to match, or the check will report the page and line.
+
+Constant values live in the deployed bytecode, so the check reads them over JSON-RPC. Set `ETH_RPC_URL` to use your own endpoint; it falls back to a public one.
+
+## Checks on a pull request
+
+**Build** runs `npm ci` and `npm run build`. A failure here belongs to this repository and blocks the merge.
+
+**Contract docs drift** runs the check above on every pull request and again weekly. It reports without blocking, because it fails when contracts change rather than when the docs do. Drift found on a scheduled run opens a single tracking issue and updates that same issue until the reference matches again.
+
+## How it deploys
+
+Cloudflare builds and publishes `master` to [docs.nexusmutual.io](https://docs.nexusmutual.io/). Merging is all it takes — there is no deploy step to run, and the site is not served from GitHub Pages.


### PR DESCRIPTION
The readme was the Docusaurus scaffold, untouched since the site was created.

## What it said, and why that hurt

- **"Docusaurus 2"** — the repository is on Docusaurus 3.10.2
- **`yarn install`, `yarn start`, `yarn build`** — there is no `yarn.lock`; this repository uses npm, and the deploy runs `npm ci`
- **A "Deployment" section** describing `USE_SSH=true yarn deploy` to push a build to a `gh-pages` branch

That last one is the reason this is worth doing. The site is built from `master` by Cloudflare and has never used GitHub Pages — the Pages API returns 404 and there is no `gh-pages` branch. Anyone following the readme would have published the site to a branch nobody serves, and concluded the deploy was broken when it did not appear.

## What it says now

- what the repository is and where it publishes
- how to run and build it, and that the build is worth running before opening a PR because `onBrokenLinks` is set to `throw`
- where content lives, one line per section, and how the sidebar is generated
- how `npm run check:contract-docs` works, what the `@check` annotations are for, and what to do when you change a number that carries one
- what the two workflows do, and why one blocks and the other does not
- how it actually deploys

## Verified

Every command in it exists in `package.json`. Every link returns 200. Each claim was checked against the thing it describes rather than written from memory — which caught one error in my own first draft: I wrote that the build fails on a missing heading anchor, but `onBrokenAnchors` is not set and defaults to `warn`. Corrected to claim only broken links, which do throw.

Build passes.

## Two things I left alone

**`npm run deploy` still exists in `package.json`.** It runs `docusaurus deploy`, the gh-pages command. The readme no longer documents it, but the script is still there for someone to run by accident. Removing it is a change to `package.json` rather than to documentation, so it belongs in its own PR.

**`onBrokenAnchors` is unset**, so a link to a heading that no longer exists only warns. Setting it to `throw` would close the same class of gap the build check closes for links — also a config change, also its own PR.