### PR TITLE
ci: keep major updates out of the grouped dependabot pull request

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,13 +5,30 @@ updates:
     directory: /
     schedule:
       interval: monthly
-    open-pull-requests-limit: 1
+    open-pull-requests-limit: 5
     groups:
+      # Minor and patch updates travel together as one reviewable PR.
+      # Majors are left out of the group so each arrives on its own, with
+      # its own changelog, rather than inside a routine bump.
       npm:
         applies-to: version-updates
+        update-types:
+          - minor
+          - patch
         patterns:
           - "*"
       npm-security:
         applies-to: security-updates
+        patterns:
+          - "*"
+
+  # The workflows pin actions by major tag, so those need updating too.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 5
+    groups:
+      actions:
         patterns:
           - "*"


### PR DESCRIPTION
#130 arrived titled *"bump the npm group with 4 updates"* and contained a React major.

## What happened

The npm group matched `patterns: ["*"]` with no update-type filter, so every bump level joined one pull request:

```
@easyops-cn/docusaurus-search-local  ^0.49.1 → ^0.55.2
@mdx-js/react                        ^3.1.0  → ^3.1.1
react                                ^18.3.1 → ^19.2.8   ← major
react-dom                            ^18.3.1 → ^19.2.8   ← major
```

The React bump is fine on its merits — `@docusaurus/core` declares `react: ^18.0.0 || ^19.0.0`, and the build passes. That is not the problem. The problem is that it looked like three minor bumps and a fourth, and a major that reads as routine gets waved through.

## Changes

**Group minor and patch only.** Majors fall out of the group and arrive one per pull request, with their own release notes, which is the point at which someone should read them.

**Raise the open pull request limit from 1 to 5.** The limit counts every open version-update PR for the ecosystem, so with majors split out a single unreviewed React PR would hold back the monthly group behind it indefinitely. One was right when everything was one PR; it stops being right the moment they separate.

**Add the `github-actions` ecosystem.** The workflows added in #125 and #129 pin three actions by major tag and nothing was updating them:

```
actions/checkout@v4
actions/setup-node@v4
actions/github-script@v7
```

That gap arrived with those PRs. An unmaintained action matters here because the drift workflow runs with `issues: write`.

Security updates are untouched — the `npm-security` group still matches every update type, so an advisory fix at major level still comes straight through.

## Not included

**Auto-merging green patch bumps.** The build gate makes it possible, but merging publishes: Cloudflare deploys from `master`, so it would be auto-deploy with no human. Worth deciding deliberately rather than folding in here.

**Pinning actions to commit SHAs** rather than major tags. Stronger supply-chain posture, noisier diffs. Reasonable to skip for a docs repository, and it is a separate decision from this one.

## On #130 itself

It can merge on its own merits — CI is green and I installed and built it locally. Worth clicking through the Cloudflare preview first, particularly search and a Mermaid page, since a build only exercises the server half of a React major.