### PR TITLE
docs: add pages for buying cover, staking and claiming

### DIFF
--- a/docs/using/buy-cover.md
+++ b/docs/using/buy-cover.md
@@ -1,0 +1,54 @@
+---
+sidebar_position: 1
+---
+
+# Buy cover
+
+Cover protects a position against a defined risk for a set amount and period. It is bought in the [Nexus Mutual app](https://app.nexusmutual.io/cover).
+
+## Before you start
+
+You need to be a [member](/overview/membership), and you need the cover asset you intend to pay in.
+
+Check that the risk you want covered has a listing. The [product index](https://nexusmutual.io/product-index) is the current list of everything the Mutual covers; the [cover products](/overview/cover-products/) pages explain what each product protects against.
+
+## What you choose
+
+**The listing.** The specific thing being covered, such as one protocol. Each listing is sold under a product, and the product is what sets the cover wording.
+
+**The amount.** How much of the position you want covered. This does not have to be the whole position.
+
+**The period.** Between 28 and 365 days. Cover starts when you buy it.
+
+**The cover asset.** The asset the cover is denominated in and would be paid out in.
+
+The price comes from the staking pools backing that listing, so it moves with how much of their capacity is already in use. See [Pricing](/protocol/pricing) for how that works.
+
+## Proof of loss is collected upfront
+
+Most cover requires you to say what is being protected at the point of purchase — typically the addresses or positions the cover applies to. This is recorded with the cover and cannot be changed afterwards.
+
+Getting this wrong is the most common reason a claim fails. A loss on an address you did not list is not covered, however genuine the loss.
+
+Check which details a listing requires before you buy, and check them again before you confirm.
+
+## What you receive
+
+Cover is held as an NFT in the address that bought it. It can be transferred or sold along with the position it protects, and whoever holds it can claim on it.
+
+## Read the cover wording
+
+The wording is the contract. It defines what counts as a loss, what is excluded, and what evidence you need. Every claim is assessed against it by the [Claims Committee](/protocol/claims-assessment).
+
+Two things in it are worth knowing before you buy rather than after a loss:
+
+- the **grace period**, which is how long after the cover expires you can still file a claim for a loss that happened while it was active. It varies by product, from a couple of weeks to several months.
+- the **deductible**, where one applies. Losses below it are not claimable.
+
+Each product's page links its wording, and the wordings are also published on IPFS.
+
+## After buying
+
+Your cover appears in the [app](https://app.nexusmutual.io/dashboard). If you suffer a loss, see [File a claim](/using/file-a-claim).
+
+Cover does not renew automatically. When it expires, coverage stops.

--- a/docs/using/file-a-claim.md
+++ b/docs/using/file-a-claim.md
@@ -1,0 +1,57 @@
+---
+sidebar_position: 3
+---
+
+# File a claim
+
+A claim is filed against cover you hold, in the [Nexus Mutual app](https://app.nexusmutual.io/claims). The [Claims Committee](/protocol/claims-assessment) assesses it against the cover wording and votes on the outcome.
+
+## Before you start
+
+You must hold the cover and be a [member](/overview/membership). If you bought cover without joining, you need to join before you can claim.
+
+Check two things first:
+
+- **the grace period has not passed.** You can claim after cover expires, but only within the grace period set by the product. It varies, from a couple of weeks to several months.
+- **the loss meets the cover wording.** The wording defines what counts as a loss and what is excluded. If there is a deductible, losses below it are not claimable.
+
+The Claims Committee can help you check both, and calculate the loss, before you file. Reach them through the in-app chat or the [contact form](https://nexusmutual.io/contact). Doing this first is worth it.
+
+## The deposit
+
+<!-- @check Claims.CLAIM_DEPOSIT_IN_ETH = 0.05 ether -->
+Filing requires a deposit of 0.05 ETH, submitted with the claim.
+
+- **Claim accepted** — the deposit is returned along with the payout.
+- **Claim assessed as a draw** — the deposit can be retrieved.
+- **Claim denied** — the deposit is not returned.
+
+It exists to make frivolous claims cost something. It is not a fee on genuine claims.
+
+## What you submit
+
+**Incident details.** What happened, when, and where. Links to the transactions, a post-mortem, or anything else that establishes the event.
+
+**Proof of loss.** For most cover this was recorded when you bought it — the addresses or positions the cover applies to. Where it was not, you provide it now.
+
+**The amount.** What you are claiming, after any deductible. It cannot exceed the cover amount.
+
+You review everything before it goes onchain.
+
+## What happens next
+
+The Claims Committee reviews the claim and votes. Voting stays open for **at least 72 hours**, and assessors record the reasoning behind their vote, which you can read once voting closes.
+
+A **24-hour cooldown** follows, during which the Advisory Board can act if a vote was fraudulent.
+
+If the claim is accepted you have **30 days** to redeem the payout. It is paid in the cover asset, from the capital pool, and the stake backing that cover is burned.
+
+## If your claim is denied
+
+You can file again. A denied claim is usually a claim the evidence did not establish, so another submission is worth making only with something the first one lacked — a clearer link between the loss and the covered position, or evidence of the amount.
+
+The reasoning recorded by the assessors tells you what was missing.
+
+## Where to look
+
+[Claim assessment](/protocol/claims-assessment) covers the process and who assesses claims. [Claims history](/overview/claims-history/) has every past claim, including the denied ones and why.

--- a/docs/using/stake.md
+++ b/docs/using/stake.md
@@ -1,0 +1,48 @@
+---
+sidebar_position: 2
+---
+
+# Stake NXM
+
+Staking NXM backs cover on chosen listings. Stakers earn a share of the fees paid on cover their stake supports, and carry the losses when a claim on it is paid. Staking happens in the [Nexus Mutual app](https://app.nexusmutual.io/stake).
+
+## Before you start
+
+You need to be a [member](/overview/membership) and to hold NXM.
+
+## Two ways to stake
+
+**Delegate to a pool.** You choose a staking pool and deposit into it. The pool manager decides which listings the pool backs, at what price, and with what weight. This is how most members stake.
+
+**Run a pool.** You create a pool, choose the listings it backs, and set the prices and weights yourself. Other members can then delegate into it. This is a risk management business, and the returns and losses follow from your own pricing.
+
+Either way the stake is at risk in the same way. Delegating chooses who makes the decisions, not whether the risk applies.
+
+## Staking periods
+
+<!-- @check StakingProducts.TRANCHE_DURATION = 91 days -->
+Stake is committed in fixed 91-day periods, called tranches. You choose how many consecutive tranches to stake across, up to eight, so the longest commitment is around two years.
+
+Stake in a tranche is locked until that tranche ends. You can extend into later tranches before it expires, or withdraw once it has.
+
+Tranches have fixed calendar boundaries, so the first one you stake into is usually shorter than 91 days.
+
+## What you earn
+
+Stakers receive a share of the fees paid when cover is bought on the listings their stake backs. Rewards accrue over the life of that cover rather than arriving at purchase, and pool managers take a fee on them.
+
+Rewards are claimed rather than compounded automatically.
+
+## What you risk
+
+**Your stake is burned when a claim is paid** on a listing your stake was backing. This is the point of staking: underwriters carry the losses, and the payout to the cover holder comes from the capital pool.
+
+The loss is proportional to how much of the pool's capacity was allocated to the listing that was claimed on. A pool concentrated in one listing is exposed to that listing; a pool spread across many is exposed to all of them.
+
+Because the same stake can back several listings at once, up to the pool's maximum total weight, losses on more than one listing can compound.
+
+Staking is not a yield product with a downside case. Deciding what to stake on is a risk decision, and it is the decision the rewards are paid for.
+
+## Where to look
+
+[Staking](/protocol/staking/) covers the mechanics in depth, [Staking pools](/protocol/staking/staking-pools) covers running one, and [Capacity](/protocol/capacity) explains how staked NXM turns into cover capacity.

--- a/docs/using/using.md
+++ b/docs/using/using.md
@@ -1,0 +1,16 @@
+---
+sidebar_position: 2.5
+description: How to buy cover, stake NXM, and file a claim.
+---
+
+# Using Nexus Mutual
+
+The rest of the documentation explains how the Mutual works. This section covers the things members actually do.
+
+- **[Buy cover](/using/buy-cover)** — protect a position against a risk
+- **[Stake NXM](/using/stake)** — underwrite risk and earn a share of cover fees
+- **[File a claim](/using/file-a-claim)** — claim on cover after a loss
+
+Everything here happens in the [Nexus Mutual app](https://app.nexusmutual.io/), and everything here requires [membership](/overview/membership).
+
+These pages describe what you need, what happens, and what to expect. They avoid walking through screens, which change more often than the process does.

--- a/static/llms.txt
+++ b/static/llms.txt
@@ -32,6 +32,13 @@ These docs describe the protocol, the cover products, how claims are assessed, a
 - [BlockFi Halted Withdrawals | November 2022](https://docs.nexusmutual.io/overview/claims-history/blockfi): A total of $30,590.64 was paid out for Claims V1 #174 and #177.
 - [Euler Finance Exploit | March 2023](https://docs.nexusmutual.io/overview/claims-history/euler): A total of $2,389,227.88 was paid out for Euler Finance Protocol Cover Claims V2 #0, #2, #3, #4, #5, #6, #7, #8, and #11.
 
+## Using Nexus Mutual
+
+- [Using Nexus Mutual](https://docs.nexusmutual.io/using/): How to buy cover, stake NXM, and file a claim.
+- [Buy cover](https://docs.nexusmutual.io/using/buy-cover): Cover protects a position against a defined risk for a set amount and period.
+- [Stake NXM](https://docs.nexusmutual.io/using/stake): Staking NXM backs cover on chosen listings.
+- [File a claim](https://docs.nexusmutual.io/using/file-a-claim): A claim is filed against cover you hold, in the Nexus Mutual app.
+
 ## The Nexus Mutual Protocol
 
 - [The Nexus Mutual Protocol](https://docs.nexusmutual.io/protocol/): Nexus Mutual is a decentralized insurance alternative that allows people to join as members and share risk with others.


### PR DESCRIPTION
The docs explain how the protocol works and never say how to use it.

> Stacked on #134 so `llms.txt` lists the new pages. Retarget to `master` once that merges.

## The gap

There is no page that tells a member how to buy cover, how to stake, or how to file a claim. `protocol/cover.md` explains that cover is tokenised and transferable; it does not say how to buy it. Only two pages in the entire site link into `app.nexusmutual.io`.

The FAQ has been absorbing the difference — "How do I become a member?", "How do I provide proof of loss?", "What does it mean to delegate my staked NXM?". Task questions collecting in an FAQ is the symptom; the structure having nowhere to put them is the cause.

## What this adds

A section for what members do, kept separate from how the protocol works.

**[Buy cover](https://docs.nexusmutual.io/using/buy-cover)** — what you choose, and that **proof of loss is recorded at purchase and cannot be changed afterwards**. That is the most common reason a genuine claim fails, and it is currently only discoverable by reading the claims page after the fact. Also flags the two things in the wording worth reading before a loss rather than after: the grace period and the deductible.

**[Stake NXM](https://docs.nexusmutual.io/using/stake)** — delegating against running a pool, the 91-day periods, rewards, and that **the stake is burned when a claim is paid**. The burn is the point of staking rather than a risk footnote, so it is stated that way.

**[File a claim](https://docs.nexusmutual.io/using/file-a-claim)** — the grace period, the deposit, what to submit, and the timeline. Including something not documented anywhere: the 0.05 ETH deposit is **returned on an accepted claim and on a draw, and kept when a claim is denied**.

## Scope discipline

These describe what happens, not which buttons to press. The app changes more often than the process does, and a page full of screen descriptions rots the way the product catalogue did.

Where I could not verify something, it is not here. There is no walkthrough of the purchase screens, because I do not know them and inventing them would be worse than omitting them.

## Verified

- Every app route linked returns 200: `/cover`, `/stake`, `/claims`, `/dashboard`, plus the product index and contact form
- The claim deposit and staking period carry `@check` annotations and pass against mainnet — 36 values now verified
- Deposit behaviour read from `Claims.sol`: `redeemClaimPayout` returns it with the payout, `retrieveDeposit` requires a `DRAW` outcome, and nothing returns it on a denial
- Grace periods deliberately described as varying by product rather than given a number, because they do: 35 days on Single Protocol Cover, 120 on Custody, 14 on Yield Token
- Uses **listing** and **product** per the convention

## Worth a second opinion

The claims page says the Claims Committee can help you check the wording and calculate the loss before you file, and that doing so is worth it. That reflects what `claims-assessment.md` already says, but it is advice rather than mechanics — flagging it in case you would rather it were phrased differently.