### PR TITLE
ci: fail the build on broken anchors, and drop the gh-pages leftovers

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -10,13 +10,11 @@ async function createConfigAsync() {
     url: "https://docs.nexusmutual.io/",
     baseUrl: "/",
     onBrokenLinks: "throw",
-    onBrokenMarkdownLinks: "warn",
+    onBrokenAnchors: "throw",
     favicon: "img/NXM-Spinner-Green.svg",
 
-    // GitHub pages deployment config.
-    // If you aren't using GitHub pages, you don't need these.
-    organizationName: "NexusMutual", // Usually your GitHub org/user name.
-    projectName: "NexusMutual/docs", // Usually your repo name.
+    organizationName: "NexusMutual",
+    projectName: "NexusMutual/docs",
     i18n: {
       defaultLocale: "en",
       locales: ["en"],
@@ -24,6 +22,9 @@ async function createConfigAsync() {
 
     markdown: {
       mermaid: true,
+      hooks: {
+        onBrokenMarkdownLinks: "warn",
+      },
       mdx1Compat: {
         comments: true,
         admonitions: true,

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "start": "docusaurus start",
     "build": "docusaurus build",
     "swizzle": "docusaurus swizzle",
-    "deploy": "docusaurus deploy",
     "clear": "docusaurus clear",
     "serve": "docusaurus serve",
     "write-translations": "docusaurus write-translations",


### PR DESCRIPTION
Three things the configuration claimed that were not true. All flagged in #131 and left for their own PR.

## Broken anchors passed the build

`onBrokenAnchors` was unset, so it defaulted to `warn`. A link to a **page** that no longer exists failed the build; a link to a **heading** that no longer exists did not. Given the amount of internal linking here, that is a gap worth closing.

There are no broken anchors today, so this locks in the current state rather than fixing a backlog.

Verified it works by adding a deliberate one:

```
[ERROR] Docusaurus found broken anchors!
  - Broken anchor on source page path = /:
```

## A deprecation warning on every build

`onBrokenMarkdownLinks` sat at the top level, which Docusaurus deprecated:

> The `siteConfig.onBrokenMarkdownLinks` config option is deprecated and will be removed in Docusaurus v4. Please migrate and move this option to `siteConfig.markdown.hooks.onBrokenMarkdownLinks` instead.

Moved under `markdown.hooks`, which exists in 3.10.2. **The build now runs with no warnings at all.**

## A deploy command that would publish to nowhere

`npm run deploy` ran `docusaurus deploy`, which builds and force-pushes to a `gh-pages` branch. The site is built from `master` by Cloudflare and has never used GitHub Pages — the Pages API returns 404 and no `gh-pages` branch exists.

Anyone running it would have published the site to a branch nobody serves, then wondered why nothing changed. Removed, along with the comment describing this repository as a GitHub Pages deployment.

`organizationName` and `projectName` stay: Docusaurus uses them for the edit-this-page links, independent of deployment.

## Verified

Build passes clean, with no warnings, and the anchor check demonstrably fails when given a broken anchor.