### PR TITLE
docs: establish the RWI Vault as a separate product, with a contract reference

### DIFF
--- a/docs/developers/developers.md
+++ b/docs/developers/developers.md
@@ -10,6 +10,7 @@ The Nexus Mutual protocol is designed to enable easy integrations and allow deve
 * [User Flows](/developers/user-flows/cover-buyer) — how buying cover, staking, and managing a pool work end to end
 * [Diagrams](/developers/Diagrams/) — contract relationships and user journeys
 * [Point of Sale Integrations](/developers/pos-integrations) — sell cover from your own frontend
+* [RWI Vault](/rwi-vault/contracts/) — the vault contracts, which ship separately from the protocol
 
 ## Libraries and APIs
 
@@ -18,3 +19,5 @@ The Nexus Mutual protocol is designed to enable easy integrations and allow deve
 **[`@nexusmutual/deployments`](https://www.npmjs.com/package/@nexusmutual/deployments)** publishes the deployed addresses and ABIs, versioned with the contracts.
 
 **[The Nexus Mutual API](https://api.nexusmutual.io/v2/api/docs/)** serves quotes, capacity, and product data. The SDK calls it for you, and you can call it directly.
+
+**[`@nexusmutual/rwi-vault-deployments`](https://www.npmjs.com/package/@nexusmutual/rwi-vault-deployments)** publishes the addresses and ABIs for the [RWI Vault](/rwi-vault/contracts/), which is deployed and versioned on its own.

--- a/docs/governance/governance.md
+++ b/docs/governance/governance.md
@@ -6,6 +6,8 @@ sidebar_position: 6
 
 Nexus Mutual is an onchain discretionary mutual governed by its members. The Mutual uses an optimistic governance model where the Advisory Board (AB) creates a proposal and sets the default outcome.
 
+This page covers the governance of the Mutual and its protocol. The [Real World Insurance Vault](/rwi-vault/) is a separate product and is [governed separately](/rwi-vault/governance).
+
 The AB creates a proposal in parallel on the [Nexus Mutual DAO Snapshot space](https://snapshot.box/#/s:community.nexusmutual.eth), where Nexus Mutual members can vote to reject the default outcome. If Nexus Mutual members vote and meet the quorum for rejection, the AB's default outcome is rejected and the proposal does not move forward.
 
 Where a proposal requires a change onchain, the Advisory Board enacts the outcome of the Snapshot vote through the `Governor` contract, exactly as members voted. See [Onchain execution](#onchain-execution) below.

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -13,5 +13,5 @@ Nexus Mutual is an onchain discretionary mutual. Members pool capital, buy cover
 - **[Claim assessment](/protocol/claims-assessment)** — how a claim is decided
 - **[Governance](/governance/)** — proposals, the Advisory Board, and the DAO
 - **[Developers](/developers/)** — contract reference, integration guides and diagrams
-- **[Real World Insurance Vault](/rwi-vault/)** — depositing, yield and risks
+- **[Real World Insurance Vault](/rwi-vault/)** — a separate product, with its own contracts and governance
 - **[Resources](/resources/)** — audits, FAQ and a glossary of the terms used here

--- a/docs/resources/audits-and-security.md
+++ b/docs/resources/audits-and-security.md
@@ -50,7 +50,7 @@ The ERC-7540 vault contracts used for real-world investments, reviewed across an
 
 - **Reviewed by:** iosiro
 - **Report:** [Nexus Mutual RWI Vault Smart Contract Audit](https://iosiro.com/audits/nexus-mutual-rwi-vault-smart-contract-audit)
-- **Repository:** `NexusMutual/rwa-vault`
+- **Repository:** [`NexusMutual/rwi-vault`](https://github.com/NexusMutual/rwi-vault)
 
 ### Cover edits, limit orders and staking pool fix — March 2025
 

--- a/docs/rwi-vault/approval.md
+++ b/docs/rwi-vault/approval.md
@@ -24,12 +24,12 @@ Approved depositors can access the full range of Vault actions:
 
 ## Requirements
 
-Before you complete the membership process, be sure to read the Know-Your-Customer (KYC) and Sophisticated Investor requirements.
+Before you start the approval process, be sure to read the Know-Your-Customer (KYC) and Sophisticated Investor requirements.
 
 - **KYC / KYB / AML**: To interact with the Vault, you will need to verify your identity through the Know-Your-Customer / Know-your-Business / Anti-Money-Laundering process.
 - **Sophisticated Investor Requirement**: The Vault is not open to retail investors. Depending on the jurisdiction, you may be required to prove your status as a sophisticated investor with additional documentation.
 
-While the Ethereum address you use for your registered wallet address can be changed later on, it's strongly recommended that you use a hardware wallet to generate an address that will be used as your address for interacting with the Vault.
+While the Ethereum address you use for your registered wallet address can be changed later on, the change has to be signed by the currently registered wallet. It's strongly recommended that you use a hardware wallet to generate an address that will be used as your address for interacting with the Vault.
 
 ## Restricted Countries List
 

--- a/docs/rwi-vault/contracts/Locks.md
+++ b/docs/rwi-vault/contracts/Locks.md
@@ -1,0 +1,127 @@
+---
+sidebar_position: 3
+---
+
+# Locks
+
+## Overview
+
+The `Locks` contract holds RWIV that members have committed for a fixed period, and pays out the [bonuses](/rwi-vault/yield-structure/bonuses/) that commitment earns. A member can hold any number of locks at once, each with its own amount and end date.
+
+Locking does not change how RWIV accrues. The baseline yield is carried by the share price, so locked shares gain value exactly as unlocked ones do, and the lock is what makes a member eligible for a share of excess returns on top.
+
+---
+
+## Key Concepts
+
+### Locks
+
+```solidity
+struct Lock {
+  uint96 shares;
+  uint32 startTime;
+  uint32 period;
+}
+```
+
+A lock ends at `startTime + period`, and the shares cannot be withdrawn before then. Locks are stored per member in an append-only array, so `lockId` is an index into that array and is never reused. Withdrawing zeroes the entry rather than removing it.
+
+### Lock periods
+
+<!-- @check Locks.MIN_LOCK_PERIOD = 30 days -->
+<!-- @check Locks.MAX_LOCK_PERIOD = 732 days -->
+```solidity
+uint public constant MIN_LOCK_PERIOD = 30 days;
+uint public constant MAX_LOCK_PERIOD = 732 days;
+```
+
+Any period between the two is accepted. The app offers a few fixed durations, but the contract does not restrict the choice to those.
+
+### Points and bonuses
+
+Points are calculated offchain from the locks recorded here, and the [rate they earn at](/rwi-vault/yield-structure/bonuses/#bonus-earning-rate) rises with the period committed. Bonuses are paid in USDC, straight to member addresses, and are not accrued in the contract — `addReward` transfers them in the same call.
+
+---
+
+## Mutative Functions
+
+### `lockShares`
+
+Locks RWIV the caller already holds. Transfers the shares to this contract and opens a new lock.
+
+```solidity
+function lockShares(uint shares, uint period) external;
+```
+
+The caller must be an active member and `period` must be within the bounds above.
+
+### `lockSharesOnDeposit`
+
+Opens a lock for shares minted straight from a deposit. Callable only by [`RWIVault`](/rwi-vault/contracts/RWIVault), which uses it for `requestDepositAndLock`.
+
+```solidity
+function lockSharesOnDeposit(uint shares, uint memberId, uint period) external;
+```
+
+### `editLock`
+
+Adds shares to an existing lock, extends it, or both.
+
+```solidity
+function editLock(uint lockId, uint topUpShares, uint period) external;
+```
+
+| Parameter     | Description                                             |
+| ------------- | ------------------------------------------------------- |
+| `lockId`      | The lock to edit. Must not have ended.                   |
+| `topUpShares` | Shares to add. May be zero.                              |
+| `period`      | Time to add to the period. May be zero.                  |
+
+`period` extends the lock rather than replacing it, and the check is on what remains: the time from now to the new end date must be within `MIN_LOCK_PERIOD` and `MAX_LOCK_PERIOD`. A lock with three days left cannot be topped up without also extending it past the minimum.
+
+An ended lock cannot be edited. Withdraw it and open a new one.
+
+### `withdrawShares`
+
+Returns the shares from an ended lock to the member.
+
+```solidity
+function withdrawShares(uint lockId) external;
+```
+
+Reverts while the lock is still running. There is no early exit and no penalty route out.
+
+### `addReward`
+
+Pays bonuses. Vault Operator only.
+
+```solidity
+function addReward(
+  uint[] calldata memberIds,
+  uint[] calldata assetAmounts,
+  address asset,
+  uint totalAssetAmounts,
+  uint snapshotTimestamp
+) external;
+```
+
+| Parameter           | Description                                                     |
+| ------------------- | --------------------------------------------------------------- |
+| `memberIds`         | Who is paid.                                                     |
+| `assetAmounts`      | How much each is paid, aligned with `memberIds`.                  |
+| `asset`             | The asset paid in, USDC in practice.                              |
+| `totalAssetAmounts` | The sum of `assetAmounts`, checked against it.                     |
+| `snapshotTimestamp` | The quarter-end the distribution was calculated at, for the event. |
+
+The amounts come from the offchain points calculation. `totalAssetAmounts` has to match their sum exactly, so a distribution that was assembled wrongly reverts rather than paying out.
+
+---
+
+## View Functions
+
+```solidity
+function getMemberLock(uint memberId, uint lockId) external view returns (Lock memory);
+function getAllMemberLocks(uint memberId) external view returns (Lock[] memory);
+```
+
+`getAllMemberLocks` includes withdrawn locks, which read as zeroed. `getMemberLock` reverts on an id that was never issued.

--- a/docs/rwi-vault/contracts/RWIRegistry.md
+++ b/docs/rwi-vault/contracts/RWIRegistry.md
@@ -1,0 +1,166 @@
+---
+sidebar_position: 4
+---
+
+# RWIRegistry
+
+## Overview
+
+The `RWIRegistry` contract is the vault system's address book, member register and pause switch. `RWIVault` and `Locks` resolve every address they need through it, and check every permission against it.
+
+It is the vault's own registry and holds no relationship to the core protocol's `Registry`. A Nexus Mutual member is not a vault member, and the reverse is equally true.
+
+---
+
+## Key Concepts
+
+### Contract indexes
+
+Every contract and role in the system has an index, and each index is a single bit. Authorisation is a bitmask, so one check can admit several callers.
+
+```solidity
+struct Contract {
+  address payable addr;
+  bool isProxy;
+}
+```
+
+| Index                   | Value | Holder                                        |
+| ----------------------- | ----- | --------------------------------------------- |
+| `C_REGISTRY`            | 1     | This contract                                  |
+| `C_GOVERNOR`            | 2     | Governor, which upgrades the contracts          |
+| `C_VAULT`               | 4     | `RWIVault`                                     |
+| `C_LOCKS`               | 8     | `Locks`                                        |
+| `A_VAULT_OPERATOR`      | 16    | Vault Operator multisig                        |
+| `A_MEMBERSHIP_OPERATOR` | 32    | The address that admits and removes depositors  |
+
+Indexes marked `isProxy` were deployed by this contract and are upgraded through it.
+
+### Members
+
+Members are recorded by id in both directions: id to address, and address to id. Ids are issued in sequence and are never reused, including after a member is removed, so an id is a stable reference to a depositor across address changes.
+
+A member id of zero means not a member. That is the value the vault's own checks look for, so an address that has never been admitted and one that has been removed are treated the same way.
+
+### Pause
+
+```solidity
+struct SystemPause {
+  uint48 config;
+  uint48 proposedConfig;
+  address proposer;
+}
+```
+
+`config` is a bitmap of what is paused.
+
+| Flag           | Value | Stops                                              |
+| -------------- | ----- | -------------------------------------------------- |
+| `PAUSE_GLOBAL` | 1     | Everything pausable, whatever else is set          |
+| `PAUSE_VAULT`  | 2     | Deposits, redemptions, fulfilment and cancellation |
+| `PAUSE_LOCKS`  | 4     | Locking, editing a lock and withdrawing from one   |
+
+Changing it takes two emergency admins. Views are never paused, and neither are RWIV transfers.
+
+---
+
+## Mutative Functions
+
+### `addMember`
+
+Admits a depositor, issuing the next member id. Membership Operator only.
+
+```solidity
+function addMember(address member) external;
+```
+
+Called once the depositor has completed the vault's [approval process](/rwi-vault/approval). Reverts if the address is already a member.
+
+### `changeMemberAddress`
+
+Moves the caller's member id to a new address. The member calls this themselves, from the address currently registered.
+
+```solidity
+function changeMemberAddress(address newAddress) external;
+```
+
+The id, and so everything recorded against it — open requests, locks — carries over. RWIV does not: it is a token balance and has to be transferred separately.
+
+### `removeMember`
+
+Removes a member. Callable by the member or the Membership Operator.
+
+```solidity
+function removeMember(uint memberId) external;
+```
+
+The id is retired rather than freed. Anything open against it, such as a pending request, resolves to the Vault Operator afterwards, because there is no longer an address to pay.
+
+### `proposePauseConfig` and `confirmPauseConfig`
+
+Set the pause bitmap. Emergency admins only, and the proposer cannot confirm their own proposal, so it takes two of them.
+
+```solidity
+function proposePauseConfig(uint config) external;
+function confirmPauseConfig(uint config) external;
+```
+
+`confirmPauseConfig` takes the value again and reverts unless it matches what was proposed.
+
+### `setEmergencyAdmin`
+
+Grants or revokes emergency admin. Governor only.
+
+```solidity
+function setEmergencyAdmin(address _emergencyAdmin, bool enabled) external;
+```
+
+### Contract management
+
+Governor only. `deployContract` puts an implementation behind a new proxy, at an address determined by the salt, `addContract` registers an address that already exists, and `upgradeContract` points an existing proxy at a new implementation. An index can only be filled while it is empty, and the Governor's own index cannot be removed.
+
+```solidity
+function deployContract(uint index, bytes32 salt, address implementation) external;
+function addContract(uint index, address contractAddress, bool isProxy) external;
+function upgradeContract(uint index, address implementation) external;
+function removeContract(uint index) external;
+```
+
+---
+
+## View Functions
+
+### Members
+
+```solidity
+function isMember(address member) external view returns (bool);
+function getMemberId(address member) external view returns (uint);
+function getMemberAddress(uint memberId) external view returns (address);
+function getMemberCount() external view returns (uint);
+function getLastMemberId() external view returns (uint);
+```
+
+`getMemberCount` is how many members there are now; `getLastMemberId` is the highest id issued. They diverge once anyone has been removed.
+
+### Addresses
+
+```solidity
+function getContractAddressByIndex(uint index) external view returns (address payable);
+function getContractIndexByAddress(address contractAddress) external view returns (uint);
+function getContracts(uint[] memory indexes) external view returns (Contract[] memory);
+function isProxyContract(uint index) external view returns (bool);
+function isValidContractIndex(uint index) external pure returns (bool);
+```
+
+These revert rather than returning zero when the index or address is not registered, and `isValidContractIndex` rejects anything that is not a single bit. One consequence is worth knowing: because the authorisation checks look a caller up here, an unauthorised call from an unregistered address fails with `ContractDoesNotExist` from the registry rather than `Unauthorized` from the contract being called.
+
+### Pause
+
+```solidity
+function getPauseConfig() external view returns (uint config);
+function getSystemPause() external view returns (SystemPause memory);
+function isPaused(uint mask) external view returns (bool);
+function isEmergencyAdmin(address member) external view returns (bool);
+```
+
+`isPaused` folds `PAUSE_GLOBAL` into the mask, so it answers the question a caller actually has. `getSystemPause` is the one place to see a proposed change that has not been confirmed.

--- a/docs/rwi-vault/contracts/RWIVault.md
+++ b/docs/rwi-vault/contracts/RWIVault.md
@@ -1,0 +1,263 @@
+---
+sidebar_position: 2
+---
+
+# RWIVault
+
+## Overview
+
+The `RWIVault` contract takes USDC deposits from approved depositors and issues RWIV, whose redemption value grows at a fixed per-second rate. Deposits and redemptions are asynchronous: a member submits a request, and the Vault Operator fulfils it.
+
+Read [Contracts](/rwi-vault/contracts/) first for how the contracts fit together and which parts of ERC-7540 are implemented.
+
+---
+
+## Key Concepts
+
+### Requests
+
+A request is created by the member and closed by the Vault Operator. Deposit and redeem requests have separate id sequences, both starting at 1.
+
+```solidity
+enum RequestStatus { PENDING, FULFILLED, CANCELED }
+
+struct DepositRequestData {
+  uint96 assets;
+  uint96 fulfilledAssets;
+  uint32 memberId;
+  uint32 lockPeriod;
+  RequestStatus status;
+}
+
+struct RedeemRequestData {
+  uint96 shares;
+  uint96 fulfilledShares;
+  uint32 memberId;
+  RequestStatus status;
+}
+```
+
+| Field             | Description                                                              |
+| ----------------- | ------------------------------------------------------------------------ |
+| `assets`          | USDC requested, held by the vault until the request closes.              |
+| `shares`          | RWIV offered for redemption, held by the vault until the request closes.  |
+| `fulfilled*`      | How much has been fulfilled so far.                                      |
+| `memberId`        | The requester, recorded as an id rather than an address.                  |
+| `lockPeriod`      | Non-zero when the deposit was made through `requestDepositAndLock`.       |
+
+A request records the member id, not the address. If a member is removed from the registry while a request is open, the assets or shares go to the Vault Operator when it closes, because there is no longer an address to send them to.
+
+### Share price
+
+The price of RWIV is a single rate, in WAD, that compounds every second from the point it was last changed.
+
+```solidity
+uint public constant WAD = 1e18;
+
+struct BaseRateConfig {
+  uint64 startRate;
+  uint64 ratePerSecond;
+  uint32 activeFrom;
+  uint64 proposedRate;
+  uint32 proposedActivationTime;
+}
+```
+
+The current rate is `startRate * ratePerSecond ^ (block.timestamp - activeFrom)`, in WAD arithmetic. `convertToAssets` multiplies shares by it, `convertToShares` divides, and both round down.
+
+Nothing else moves the price. Deposits, redemptions and vault performance do not, which is what makes the yield fixed rather than a share of returns.
+
+`getRatePerSecond()` returns the per-second factor. `getBaseApy()` returns the same factor compounded over 365 days, so it is a growth factor and not a percentage: `1.05e18` means 5% a year.
+
+### Rate bounds
+
+```solidity
+uint public constant MIN_RATE_PROPOSAL_TIME = 90 days;
+uint public constant MAX_APY = 1.5e18;
+```
+
+A proposed rate must be at least `WAD`, so the price can never fall, and must annualise to no more than `MAX_APY`, a ceiling of 50% a year. `MIN_RATE_PROPOSAL_TIME` is the notice a change carries: the activation time must be more than 90 days out.
+
+### Asset cap
+
+`assetCap` bounds `totalAssets()`, the redemption value of all RWIV in issue. A deposit request that would leave `totalAssets()` at or below the cap is fulfilled in the same transaction. One that would exceed it stays pending until the Vault Operator fulfils or cancels it, which is how the operator paces inflows against what the Insurance Partners can take.
+
+---
+
+## Mutative Functions
+
+### `requestDeposit`
+
+Submits a deposit request. Pulls the USDC immediately, and fulfils the request in the same transaction if it fits under the asset cap.
+
+```solidity
+function requestDeposit(
+  uint assets,
+  address controller,
+  address owner
+) external returns (uint requestId);
+```
+
+| Parameter    | Description                                     |
+| ------------ | ----------------------------------------------- |
+| `assets`     | USDC to deposit.                                |
+| `controller` | Must be `msg.sender`.                           |
+| `owner`      | Must be `msg.sender`.                           |
+
+ERC-7540 allows the controller and owner to differ from the caller. This vault does not: all three must be the same address, and it must be an active member.
+
+Shares are minted at fulfilment, at the rate current then. USDC sitting in a pending request earns nothing.
+
+### `requestDepositAndLock`
+
+The same as `requestDeposit`, except that on fulfilment the shares are minted to [`Locks`](/rwi-vault/contracts/Locks) and locked for `lockPeriod` instead of being sent to the depositor.
+
+```solidity
+function requestDepositAndLock(
+  uint assets,
+  address controller,
+  address owner,
+  uint lockPeriod
+) external returns (uint requestId);
+```
+
+`lockPeriod` is validated when the lock is created, so a period outside the bounds `Locks` allows makes fulfilment revert rather than the request.
+
+### `fulfillDeposit`
+
+Fulfils a pending deposit request. Vault Operator only.
+
+```solidity
+function fulfillDeposit(uint requestId, uint assets) external;
+```
+
+`assets` may be less than the amount requested. The difference is returned to the depositor and the request closes as `FULFILLED` regardless, so a request is fulfilled at most once and a partial fulfilment is final.
+
+Fulfilment mints `convertToShares(assets)` to the depositor and transfers the USDC to the Vault Operator.
+
+### `cancelDepositRequest`
+
+Cancels a pending deposit request and returns the USDC that has not been fulfilled. Callable by the depositor or the Vault Operator.
+
+```solidity
+function cancelDepositRequest(uint requestId) external;
+```
+
+### `requestRedeem`
+
+Submits a redemption request, transferring the RWIV to the vault. The shares leave the member's wallet at this point and cannot be transferred or sold while the request is open.
+
+```solidity
+function requestRedeem(
+  uint shares,
+  address controller,
+  address owner
+) external returns (uint requestId);
+```
+
+As with `requestDeposit`, the controller and owner must both be `msg.sender`, and it must be an active member.
+
+Shares in the queue keep accruing. The payout is computed at the rate when the request is fulfilled, not when it was submitted.
+
+### `fulfillRedeems`
+
+Pays out redemption requests in id order. Vault Operator only.
+
+```solidity
+function fulfillRedeems(uint maxRequestId, uint maxTotalAssets) external;
+```
+
+| Parameter        | Description                                                    |
+| ---------------- | -------------------------------------------------------------- |
+| `maxRequestId`   | The last request id to consider. Must have been issued.         |
+| `maxTotalAssets` | The most USDC to pay across this call.                          |
+
+The walk starts at the first request that has not been fulfilled and pays `convertToAssets` on each until `maxTotalAssets` runs out. A request that cannot be paid in full is filled as far as the remaining budget allows, keeps `PENDING` status, and stops the walk — so the queue is strictly first in, first out, and cannot be reordered by choosing arguments.
+
+The USDC comes from the Vault Operator's balance, not from the vault, so a call only succeeds while the operator holds enough to cover it.
+
+### `cancelRedeemRequest`
+
+Cancels a pending redemption request and returns the RWIV that has not been fulfilled. Callable by the member or the Vault Operator.
+
+```solidity
+function cancelRedeemRequest(uint requestId) external;
+```
+
+### `proposeBaseRateChange`
+
+Proposes a new base rate. Vault Operator only.
+
+```solidity
+function proposeBaseRateChange(uint proposalRate, uint proposalActivationTime) external;
+```
+
+| Parameter                | Description                                                        |
+| ------------------------ | ------------------------------------------------------------------ |
+| `proposalRate`           | The new per-second rate, in WAD. At least `WAD`.                   |
+| `proposalActivationTime` | When it may be executed. More than `MIN_RATE_PROPOSAL_TIME` away.  |
+
+There is one proposal slot. Proposing again overwrites what is in it, including its activation time.
+
+### `executeBaseRateChange`
+
+Applies a proposal once its activation time has passed. Anyone can call it — the notice period is the control, not the caller.
+
+```solidity
+function executeBaseRateChange() external;
+```
+
+The rate reached so far becomes the new `startRate`, so the price is continuous across the change and no accrual is lost or repeated.
+
+### `setAssetCap`
+
+Sets the asset cap. Vault Operator only.
+
+```solidity
+function setAssetCap(uint newAssetCap) external;
+```
+
+---
+
+## View Functions
+
+### Requests
+
+```solidity
+function getDepositRequests(uint[] calldata requestIds) external view returns (DepositRequestData[] memory);
+function getRedeemRequests(uint[] calldata requestIds) external view returns (RedeemRequestData[] memory);
+function pendingDepositRequest(uint requestId, address controller) external view returns (uint assets);
+function pendingRedeemRequest(uint requestId, address controller) external view returns (uint shares);
+```
+
+Unknown ids read as a zeroed struct rather than reverting, and `PENDING` is zero — so a request that does not exist looks pending. Check that `assets` or `shares` is non-zero before reading `status`.
+
+The `pending*` functions ignore the `controller` argument, which is there for ERC-7540 compatibility. A request id alone identifies a request.
+
+### Rate
+
+```solidity
+function getBaseApy() external view returns (uint);
+function getRatePerSecond() external view returns (uint);
+function getBaseRateConfig() external view returns (BaseRateConfig memory);
+```
+
+`getBaseRateConfig` is the one place to read a pending change from, through its `proposedRate` and `proposedActivationTime`.
+
+### Value
+
+```solidity
+function convertToAssets(uint shares) external view returns (uint);
+function convertToShares(uint assets) external view returns (uint);
+function totalAssets() external view returns (uint);
+function assetCap() external view returns (uint);
+```
+
+`convertToAssets(ASSET_UNIT)` is the RWIV price in USDC. RWIV uses the same decimals as the asset:
+
+<!-- @check RWIVault.ASSET_UNIT = 1e6 -->
+```solidity
+address public immutable asset;         // USDC
+uint8 public immutable assetDecimals;   // 6
+uint public immutable ASSET_UNIT;       // 1e6
+```

--- a/docs/rwi-vault/contracts/contracts.md
+++ b/docs/rwi-vault/contracts/contracts.md
@@ -1,0 +1,79 @@
+---
+sidebar_position: 8
+description: The contracts behind the Real World Insurance Vault, and what an integration can and cannot rely on.
+---
+
+# Contracts
+
+The Vault takes USDC from approved depositors and issues RWIV, a share token whose redemption value grows at a fixed rate. It is a separate system from the Nexus Mutual protocol: its own repository, [`NexusMutual/rwi-vault`](https://github.com/NexusMutual/rwi-vault), its own registry, its own [governance](/rwi-vault/governance), its own deployments package, and its own release cycle. None of the protocol's contracts are in the path of a deposit or a redemption.
+
+- [RWIVault](/rwi-vault/contracts/RWIVault) — deposits, redemptions, share price and the base rate
+- [Locks](/rwi-vault/contracts/Locks) — locking RWIV to earn bonuses
+- [RWIRegistry](/rwi-vault/contracts/RWIRegistry) — members, contract addresses and the pause switch
+
+Addresses and ABIs are published in [`@nexusmutual/rwi-vault-deployments`](https://www.npmjs.com/package/@nexusmutual/rwi-vault-deployments), versioned with the vault contracts. Core protocol addresses stay in `@nexusmutual/deployments`; the two packages do not overlap.
+
+The contracts have been [audited](/resources/audits-and-security).
+
+## Three contracts and a registry
+
+`RWIRegistry` resolves every address in the system, including the roles. Each entry has an index, and every index is a single bit, so an authorisation check is a bitmask over the caller's index:
+
+| Index                    | Value | Holder                                          |
+| ------------------------ | ----- | ----------------------------------------------- |
+| `C_REGISTRY`             | 1     | `RWIRegistry`                                    |
+| `C_GOVERNOR`             | 2     | The Vault's [governor](/rwi-vault/governance), which upgrades contracts |
+| `C_VAULT`                | 4     | `RWIVault`                                       |
+| `C_LOCKS`                | 8     | `Locks`                                          |
+| `A_VAULT_OPERATOR`       | 16    | Vault Operator multisig                          |
+| `A_MEMBERSHIP_OPERATOR`  | 32    | The address that admits and removes depositors   |
+
+`RWIVault` and `Locks` sit behind upgradeable proxies deployed by the registry, which owns them, so `upgradeContract` on the registry is the route to upgrading either. The registry is itself behind a proxy, owned by the governor rather than by the registry, and is upgraded through that proxy directly. Nothing in that chain has a timelock or a separate proxy admin, so an upgrade lands in the transaction the governor submits.
+
+Reading `registry` on the vault or on `Locks` returns the registry they resolve against.
+
+The governor's own index cannot be reassigned. It holds a plain address rather than a proxy, `removeContract` rejects that index, and `addContract` only fills an index that is empty. `transferGovernor` existed on the temporary registry implementation used during deployment and is not on the deployed one. So a new governor needs a new registry implementation, which only the current governor can ship.
+
+## Membership
+
+Requesting a deposit or a redemption, and locking shares, all require an active member id in `RWIRegistry`. That register belongs to the vault. It records who has passed the vault's [approval process](/rwi-vault/approval) and is unrelated to Nexus Mutual membership — being one does not make you the other.
+
+RWIV itself carries no restriction. It is a plain ERC-20, transfers need no membership on either side, and transfers are not covered by the pause switch. So a non-member can hold RWIV and watch it accrue, but cannot mint or redeem it.
+
+Members are addressed by id rather than by address, and a member can move to a new address with `changeMemberAddress`. Anything holding a member address across transactions should resolve it from the id each time.
+
+## What of ERC-7540 is implemented
+
+The vault implements the request half of the standard and none of the claim half.
+
+| Function                                                | Status                    |
+| ------------------------------------------------------- | ------------------------- |
+| `requestDeposit`, `requestRedeem`                       | Implemented               |
+| `pendingDepositRequest`, `pendingRedeemRequest`         | Implemented               |
+| `claimableDepositRequest`, `claimableRedeemRequest`     | Reverts `NotSupported()`  |
+| `deposit`, `mint`, `withdraw`, `redeem`                 | Reverts `NotSupported()`  |
+| `setOperator`, `isOperator`                             | Reverts `NotSupported()`  |
+
+There is no claim step to call. Fulfilling a deposit mints the shares to the depositor, and fulfilling a redemption sends the USDC, both in the transaction the Vault Operator submits. Nothing is ever left claimable, which is why those functions revert rather than return zero. An integration written against the standard request-then-claim sequence will not work here.
+
+The ERC-4626 conversion and preview functions do work, and `convertToAssets` is the RWIV price. `maxDeposit` and `maxMint` return `type(uint).max` and say nothing about how much the vault will actually accept — read `assetCap` and `totalAssets` for that.
+
+## Where the assets are
+
+The vault holds USDC only between a deposit request and its fulfilment, and RWIV only between a redemption request and its fulfilment. Everything else sits with the Vault Operator, which invests it offchain: fulfilled deposits are transferred out to the operator, and redemptions are paid from the operator's balance.
+
+`totalAssets()` is therefore the redemption value of all RWIV in issue — what the vault owes — and not a balance it holds. A redemption can only be fulfilled while the operator holds enough USDC to pay it, which is why withdrawals are queued rather than immediate.
+
+## Pause
+
+`RWIRegistry` holds one pause bitmap for the whole system.
+
+| Flag           | Value | Stops                                              |
+| -------------- | ----- | -------------------------------------------------- |
+| `PAUSE_GLOBAL` | 1     | Everything pausable, whatever else is set          |
+| `PAUSE_VAULT`  | 2     | Deposits, redemptions, fulfilment and cancellation |
+| `PAUSE_LOCKS`  | 4     | Locking, editing a lock and withdrawing from one   |
+
+Setting it takes two emergency admins: one calls `proposePauseConfig`, and a different one calls `confirmPauseConfig` with the same value. `isPaused(mask)` folds `PAUSE_GLOBAL` into the mask, so it answers what a caller cares about.
+
+Views are never paused, and neither are RWIV transfers.

--- a/docs/rwi-vault/depositing.md
+++ b/docs/rwi-vault/depositing.md
@@ -8,9 +8,11 @@ sidebar_position: 2
 
 Depositing USDC requires you to submit a transaction on Ethereum. You may also be requested to approve the Vault contract to interact with your USDC ahead of depositing.
 
-When you deposit USDC, you are calling the <code>requestDeposit()</code> function on the smart contract. If the deposit doesn’t exceed the Vault Cap, the smart contract will automatically accept your USDC and you will receive an amount of RWIV tokens in return based on the current exchange rate.
+When you deposit USDC, you are calling the <code>requestDeposit()</code> function on the smart contract. If the deposit doesn’t exceed the Vault Cap, the smart contract accepts your USDC in the same transaction and you receive an amount of RWIV tokens in return based on the current exchange rate. If it would exceed the cap, the request waits for the VO.
 
-It is also possible to deposit and immediately lock the LP tokens to earn bonuses. In this case, the <code>requestDepositandLock()</code> function is called instead.
+It is also possible to deposit and immediately lock the RWIV tokens to earn bonuses. In this case, the <code>requestDepositAndLock()</code> function is called instead.
+
+A deposit starts earning the Baseline Yield when it is accepted, not when it is submitted. While a request is waiting, the USDC sits in the Vault contract and earns nothing. You can cancel a request that hasn’t been accepted and get the USDC back.
 
 ## RWIV Token
 
@@ -26,9 +28,9 @@ The RWI Vault is subject to a Vault Cap, which limits the total USDC that can be
 
 Users are still able to submit a deposit request transaction even if that deposit would exceed the Vault Cap. In this scenario, the VO can approve or reject the request:
 
-- If approved, the deposit is accepted into the Vault and RWIV tokens are issued as normal
+- If approved, the deposit is accepted into the Vault and RWIV tokens are issued as normal. The VO can also approve part of a request, in which case the rest is returned to the user
 - If rejected, the deposit amount is returned to the user
 
-The initial Vault Cap is set to 10m USDC.
+The Vault Cap was set to 10m USDC at launch. The current cap is held onchain and can be read from the Vault contract as <code>assetCap</code>.
 
 The Vault Operator can update the Vault Cap onchain as required. These updates are made according to the VO’s processes based on deposit demand, ability of [Insurance Partners](insurance-partners.md) to take in additional funds and interest accrued over time within the Vault.

--- a/docs/rwi-vault/faqs.md
+++ b/docs/rwi-vault/faqs.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 7
+sidebar_position: 9
 ---
 
 # FAQs
@@ -28,7 +28,9 @@ are restricted to approved depositors who have completed KYC/KYB and Sophisticat
 
 ## Why would I lock my RWIV?
 
-Locking RWIV tokens for longer periods better aligns the timelines of the depositors with the return emergence of the Vault Operator’s underlying investments. Depositors who lock their RWIV will be rewarded with points, with a higher earning rate for those locking for longer periods, up to a maximum lock duration of 2 years.
+Locking RWIV tokens for longer periods better aligns the timelines of the depositors with the return emergence of the Vault Operator’s underlying investments. Depositors who lock their RWIV will be rewarded with points, with a higher earning rate for those locking for longer periods, up to a maximum lock duration of 732 days.
+
+A lock can be topped up or extended while it is running, but it cannot be ended early, so locked RWIV cannot be withdrawn or sold until the period is over.
 
 Should the underlying insurance investments generate surplus returns exceeding the Baseline Yield and cost of Nexus Mutual Cover, then 60% of this excess will be distributed as USDC on a quarterly basis, in proportion to the points accumulated by individual depositors.
 

--- a/docs/rwi-vault/governance.md
+++ b/docs/rwi-vault/governance.md
@@ -1,0 +1,45 @@
+---
+sidebar_position: 6
+description: Who controls the RWI Vault, and what the contracts let each role do.
+---
+
+# Governance
+
+The RWI Vault is a separate product from the Nexus Mutual protocol, and it is governed through its own contracts rather than through the protocol's.
+
+Vault changes do not go through the [Nexus Mutual governance](/governance/) process. There is no proposal, no Snapshot vote and no member veto for a change to the Vault, and no Vault change is enacted through the protocol's `Governor` contract. The two systems have separate contracts, separate registries, separate membership registers and separate release cycles.
+
+## Who can do what
+
+Every role sits in the Vault's own [`RWIRegistry`](/rwi-vault/contracts/RWIRegistry), and the current holder of each is readable onchain.
+
+**The Governor** is the Vault's highest authority. It can upgrade the Vault contracts, register and remove contracts, and appoint or remove emergency admins. It has no role in day-to-day operations.
+
+The role is currently held by the Nexus Mutual Advisory Board multisig. It acts on the Vault directly, as a transaction on the Vault's own registry, and not through the [proposal and member vote process](/governance/) that governs the protocol.
+
+**The Vault Operator** runs the Vault. It sets the [Vault Cap](/rwi-vault/depositing#vault-cap), accepts or rejects deposit requests above that cap, fulfils [withdrawals](/rwi-vault/withdrawals), proposes changes to the [Baseline Yield](/rwi-vault/yield-structure/baseline-yield/), calculates the quarterly [NAV](/rwi-vault/yield-structure/bonuses/nav-calculation) and distributes [bonuses](/rwi-vault/yield-structure/bonuses/).
+
+**The Membership Operator** admits depositors who have completed the [approval process](/rwi-vault/approval), and removes them.
+
+**Emergency admins** can pause the Vault. It takes two of them: one proposes a pause configuration and a different one confirms the same value, so no single admin can pause or unpause alone.
+
+Operations and upgrades are separate roles in the registry, so the Vault Operator cannot upgrade the contracts and the Governor cannot run the Vault.
+
+## Upgrades
+
+The Vault contracts can be upgraded, and the Governor is the only role that can upgrade them. An upgrade takes effect as soon as it is submitted, with no waiting period.
+
+Replacing the Governor also takes an upgrade, so only the current Governor can do it. [Contracts](/rwi-vault/contracts/) covers how that works.
+
+## What no role can do
+
+The contracts limit these roles as much as they grant them.
+
+<!-- @check RWIVault.MIN_RATE_PROPOSAL_TIME = 90 days -->
+<!-- @check RWIVault.MAX_APY = 1.5e18 -->
+
+- **Nobody can move your RWIV.** There is no administrative transfer, freeze or clawback. RWIV is a plain ERC-20 and transfers are not affected by the pause switch
+- **Nobody can end a lock early**, including the depositor. Locked RWIV can be withdrawn back to the depositor's wallet when the lock period is over and not before
+- **The Baseline Yield cannot change without 90 days' notice**, cannot be set below a rate that would reduce the RWIV price, and cannot exceed a hard ceiling of 50% a year
+- **A withdrawal queue cannot be reordered.** Requests are fulfilled in the order they were made, and the Vault Operator cannot choose to skip one
+- **Deposits and withdrawals are not custody.** A pending request holds your funds in the Vault contract, and cancelling returns them to you

--- a/docs/rwi-vault/risks.md
+++ b/docs/rwi-vault/risks.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 6
+sidebar_position: 7
 ---
 
 # Risks
@@ -20,6 +20,8 @@ Risks include:
 - Unexpected economic behaviour
 - Ethereum network congestion or prolonged downtime
 - Chain reorganisations or consensus failures
+
+The contracts are upgradeable. [Governance](governance.md) covers who can upgrade them, and what no role can do regardless of an upgrade.
 
 Although Nexus Mutual Baseline Yield Cover is designed to protect against technical and economic smart contract failures, such protection is subject to Nexus Mutual’s own risk profile.
 

--- a/docs/rwi-vault/rwi-vault.md
+++ b/docs/rwi-vault/rwi-vault.md
@@ -6,6 +6,8 @@ sidebar_position: 7
 
 The Real World Insurance Vault (“RWI Vault”) allows sophisticated investors to earn yield on their USDC.
 
+The Vault is a separate product from the Nexus Mutual protocol. It has its own contracts, its own approval process for depositors, and its own [governance](governance.md). Cover, staking and claims are not involved, and NXM is not involved. The two are connected in the ways set out [below](#relationship-to-nexus-mutual).
+
 The Vault is deployed on Ethereum mainnet with infrastructure based on the ERC-7540 standard. The underlying returns are sourced by providing solvency capital and reserves off-chain to back regulated insurance policies.
 
 The [yield](yield-structure/yield-structure.md) earned by depositors consists of two components:
@@ -21,9 +23,13 @@ The Vault operations are managed by the Vault Operator (“VO”). The Vault Ope
 
 ## Relationship to Nexus Mutual
 
-The RWI Vault is owned and operated by the members of Nexus Mutual and ties in with the Mutual in several ways:
+The RWI Vault is owned by the members of Nexus Mutual and ties in with the Mutual in several ways, none of which put the Vault under the Mutual's governance:
 
 - Interaction with the Vault is available via the existing Nexus Mutual application
 - Nexus Mutual provides Cover to protect the fixed Baseline Yield of the RWI Vault
 - The Mutual participates in excess returns via a profit share mechanism
 - As the ultimate owner of the Vault’s legal entity, the Mutual benefits from the residual operating margin of the Vault Operator (VO) after meeting all obligations.
+
+## Contracts and audits
+
+The Vault contracts are documented in [Contracts](/rwi-vault/contracts/), and are covered by the [audit reports](/resources/audits-and-security).

--- a/docs/rwi-vault/withdrawals.md
+++ b/docs/rwi-vault/withdrawals.md
@@ -8,10 +8,13 @@ Withdrawals of RWIV into USDC are requested via the app by calling <code>request
 
 Upon submission:
 
+- the RWIV is transferred to the Vault contract, so it leaves your wallet and cannot be transferred or sold while the request is open
 - the request enters a withdrawal queue
 - all RWIV continues earning the baseline yield until processed by the Vault Operator
 
-Withdrawals are processed by the VO on a first-in, first-out basis as liquidity becomes available. We currently expect withdrawals to take approximately 90 days and be closely linked to the redemption windows of the initial Insurance Partner.
+Withdrawals are processed by the VO on a first-in, first-out basis as liquidity becomes available. Where there isn’t enough liquidity to fill a request, it is filled as far as the liquidity goes and the remainder stays at the front of the queue. We currently expect withdrawals to take approximately 90 days and be closely linked to the redemption windows of the initial Insurance Partner.
+
+A request that hasn’t been filled can be cancelled, and the RWIV is returned to your wallet.
 
 Note that the typical timeline for releasing loss reserves from the insurance business backed by the RWI Vault is approximately 18-24 months. We strongly encourage depositors to have this timeframe in mind when depositing into the RWI Vault.
 

--- a/docs/rwi-vault/yield-structure/baseline-yield/baseline-yield.md
+++ b/docs/rwi-vault/yield-structure/baseline-yield/baseline-yield.md
@@ -12,13 +12,14 @@ The Baseline Yield is protected by [Baseline Yield Cover](nexus-mutual-cover.md)
 
 The yield is set at a level driven by a margin above 2-year and 5-year US Treasury yields — the driving force behind mass market insurance product returns. The VO aims to target a return ~2-3% above the monthly averages of those rates but is also entitled to respond to other macro or Insurance Partner changes.
 
-The baseline yield can only be changed with a 90 day notice period by the VO by calling <code>proposeBaseApyChange()</code> onchain.
+<!-- @check RWIVault.MIN_RATE_PROPOSAL_TIME = 90 days -->
+The baseline yield can only be changed with a 90 day notice period. The VO proposes a new rate onchain with <code>proposeBaseRateChange()</code>, and it takes effect once the notice period has passed and <code>executeBaseRateChange()</code> is called.
 
 The current Baseline Yield can be found on the app.
 
 ## Accrual
 
-The Baseline Yield is applied to the value of the RWIV token programmatically, compounded per second. The value can be obtained by calling the <code>convertToShares()</code> function. Simplified calculation:
+The Baseline Yield is applied to the value of the RWIV token programmatically, compounded per second. The USDC value of an amount of RWIV can be obtained by calling the <code>convertToAssets()</code> function. Simplified calculation:
 
 <code>assetsPerShare = startAssetsPerShare * (1 + interestPerSecond) ^ secondsPassed</code>
 

--- a/docs/rwi-vault/yield-structure/bonuses/bonuses.md
+++ b/docs/rwi-vault/yield-structure/bonuses/bonuses.md
@@ -12,7 +12,7 @@ Snapshots for bonus distribution are taken at the end of each calendar quarter. 
 
 ## Bonus Earning Rate
 
-The longer a depositor locks their LP tokens, the higher the proportion of bonuses that will be distributed to them. Illustrative table of ratios below for the specific durations available in the UI, but users can lock for any duration onchain.
+The longer a depositor locks their RWIV, the higher the proportion of bonuses that will be distributed to them. Illustrative table of ratios below for the specific durations available in the UI.
 
 | Lock Period | Multiplier |
 |------------|------------|
@@ -23,11 +23,15 @@ The longer a depositor locks their LP tokens, the higher the proportion of bonus
 
 The earning rate is capped at 8x. Longer lock durations than 720 days still earn the maximum rate.
 
+<!-- @check Locks.MIN_LOCK_PERIOD = 30 days -->
+<!-- @check Locks.MAX_LOCK_PERIOD = 732 days -->
+Onchain, any lock period between 30 and 732 days is accepted, and the earning rate follows the formula below rather than the table. A lock can be topped up or extended while it is running, but there is no early exit: the RWIV can be withdrawn back to the depositor's wallet once the period is over.
+
 ## Points Formula
 
 For each locking segment:
 
-<code>earning_rate = min(8, (t_unlock - t_lock) in days / 90) * LP_token_amount / 1000</code>
+<code>earning_rate = min(8, (t_unlock - t_lock) in days / 90) * RWIV_amount / 1000</code>
 
 If there are edits to a locking position:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "@docusaurus/plugin-client-redirects": "^3.10.2",
         "@docusaurus/types": "^3.10.2",
         "@nexusmutual/deployments": "^3.4.0",
+        "@nexusmutual/rwi-vault-deployments": "^1.1.0",
         "ethers": "^6.17.0"
       },
       "engines": {
@@ -4959,6 +4960,13 @@
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/@nexusmutual/deployments/-/deployments-3.4.0.tgz",
       "integrity": "sha512-WvyRTPAbz53Y2O7cjkf1Uiqv7M6SH/EjdFrftOAr4t7r8A4iWe6pJDXJwD4YVDkSY/3mQIuWlc5MuXoKVfeCqA==",
+      "dev": true,
+      "license": "GPL-3.0"
+    },
+    "node_modules/@nexusmutual/rwi-vault-deployments": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@nexusmutual/rwi-vault-deployments/-/rwi-vault-deployments-1.1.0.tgz",
+      "integrity": "sha512-GcaOG7UZ2xjrG8BdRDTv6teDvujMmhVd1myoEww7TBBTZTupkPrYNcBS7V1jMkDIbTMYtv/8PkN/qmMlFoPLEg==",
       "dev": true,
       "license": "GPL-3.0"
     },

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@docusaurus/plugin-client-redirects": "^3.10.2",
     "@docusaurus/types": "^3.10.2",
     "@nexusmutual/deployments": "^3.4.0",
+    "@nexusmutual/rwi-vault-deployments": "^1.1.0",
     "ethers": "^6.17.0"
   },
   "browserslist": {

--- a/scripts/check-contract-docs.mjs
+++ b/scripts/check-contract-docs.mjs
@@ -3,8 +3,8 @@
  * Checks the contract reference docs against the deployed contracts.
  *
  * Three checks:
- *   1. every solidity function documented in docs/developers/contracts/*.md
- *      exists on the deployed ABI of the contract that page documents
+ *   1. every solidity function documented in a contract reference page exists
+ *      on the deployed ABI of the contract that page documents
  *   2. every page maps to a contract that is actually deployed
  *   3. every solidity constant quoted in those pages still holds the value
  *      the deployed contract returns
@@ -27,26 +27,35 @@ import { fileURLToPath } from 'node:url';
 import { ethers } from 'ethers';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
-const DOCS = path.join(ROOT, 'docs/developers/contracts');
 const ALL_DOCS = path.join(ROOT, 'docs');
 const RPC = process.env.ETH_RPC_URL || 'https://ethereum-rpc.publicnode.com';
 
-// doc file -> deployed contract name
+// doc file -> deployed contract name. Paths are relative to docs/, because the
+// RWI Vault is a separate product and its reference lives in its own section.
 const PAGES = {
-  'Assessments.md': 'Assessments',
-  'Claims.md': 'Claims',
-  'Cover.md': 'Cover',
-  'Pool.md': 'Pool',
-  'Ramm.md': 'Ramm',
-  'StakingPool.md': 'StakingPool',
-  'StakingPoolFactory.md': 'StakingPoolFactory',
-  'StakingProducts.md': 'StakingProducts',
-  'TokenController.md': 'TokenController',
+  'developers/contracts/Assessments.md': 'Assessments',
+  'developers/contracts/Claims.md': 'Claims',
+  'developers/contracts/Cover.md': 'Cover',
+  'developers/contracts/Pool.md': 'Pool',
+  'developers/contracts/Ramm.md': 'Ramm',
+  'developers/contracts/StakingPool.md': 'StakingPool',
+  'developers/contracts/StakingPoolFactory.md': 'StakingPoolFactory',
+  'developers/contracts/StakingProducts.md': 'StakingProducts',
+  'developers/contracts/TokenController.md': 'TokenController',
+  'rwi-vault/contracts/RWIVault.md': 'RWIVault',
+  'rwi-vault/contracts/Locks.md': 'Locks',
+  'rwi-vault/contracts/RWIRegistry.md': 'RWIRegistry',
 };
 
-const { addresses, abis } = await import('@nexusmutual/deployments');
+const core = await import('@nexusmutual/deployments');
+const vault = await import('@nexusmutual/rwi-vault-deployments');
 
-const read = file => fs.readFileSync(path.join(DOCS, file), 'utf8');
+// The RWI Vault ships from its own repo with its own deployments package, so
+// its contracts are merged in here. Annotations name a contract, not a package.
+const addresses = { ...core.addresses, ...vault.addresses };
+const abis = { ...core.abis, ...vault.abis };
+
+const read = file => fs.readFileSync(path.join(ALL_DOCS, file), 'utf8');
 
 const documentedFunctions = txt =>
   [...new Set([...txt.matchAll(/^\s*function\s+([A-Za-z0-9_]+)\s*\(/gm)].map(m => m[1]))];
@@ -65,6 +74,9 @@ const literal = raw => {
   if (days) return BigInt(days[1]) * 86400n;
   const hours = s.match(/^(\d+)\s*hours?$/);
   if (hours) return BigInt(hours[1]) * 3600n;
+  // The vault scales rates and its asset unit as powers of ten: 1e18, 1.5e18, 1e6.
+  const exponent = s.match(/^([\d.]+)e(\d+)$/);
+  if (exponent) return ethers.parseUnits(exponent[1], Number(exponent[2]));
   return null;
 };
 
@@ -96,7 +108,7 @@ const rows = [];
 // ---- checks 1 and 2 -------------------------------------------------------
 
 for (const [file, contract] of Object.entries(PAGES)) {
-  if (!fs.existsSync(path.join(DOCS, file))) {
+  if (!fs.existsSync(path.join(ALL_DOCS, file))) {
     problems.push(`${file}: page is missing`);
     continue;
   }
@@ -150,7 +162,7 @@ let verified = 0;
 console.log('\nConstants quoted in the reference:');
 
 for (const [file, pageContract] of Object.entries(PAGES)) {
-  if (!fs.existsSync(path.join(DOCS, file))) continue;
+  if (!fs.existsSync(path.join(ALL_DOCS, file))) continue;
 
   for (const c of documentedConstants(read(file))) {
     const expected = literal(c.raw);
@@ -357,7 +369,7 @@ if (fs.existsSync(WORDINGS)) {
   }
 }
 
-console.log(`\ndeployed contracts: ${Object.keys(addresses).length}   published ABIs: ${Object.keys(abis).length}   values verified: ${verified}`);
+console.log(`\ndeployed contracts: ${Object.keys(addresses).length} (${Object.keys(core.addresses).length} core, ${Object.keys(vault.addresses).length} vault)   published ABIs: ${Object.keys(abis).length}   values verified: ${verified}`);
 
 if (notes.length) {
   console.log('\nNot checked:');

--- a/scripts/generate-llms-txt.mjs
+++ b/scripts/generate-llms-txt.mjs
@@ -110,15 +110,23 @@ const directChildren = dir => pages.filter(p => p.dir === dir).sort(byPosition);
 
 const hasPages = dir => pages.some(p => p.dir === dir || p.dir.startsWith(dir + path.sep));
 
+/** Where a category sits, resolved as Docusaurus does: _category_.json wins. */
+const positionFor = dir => {
+  const cat = path.join(dir, '_category_.json');
+  if (fs.existsSync(cat)) {
+    try {
+      const { position } = JSON.parse(fs.readFileSync(cat, 'utf8'));
+      if (position !== undefined) return Number(position);
+    } catch {}
+  }
+  return directChildren(dir).find(p => p.isIndex)?.position ?? 99;
+};
+
 const subdirs = dir => fs.readdirSync(dir, { withFileTypes: true })
   .filter(e => e.isDirectory() && visible(e))
   .map(e => path.join(dir, e.name))
   .filter(hasPages)
-  .sort((a, b) => {
-    const ai = directChildren(a).find(p => p.isIndex)?.position ?? 99;
-    const bi = directChildren(b).find(p => p.isIndex)?.position ?? 99;
-    return ai - bi || a.localeCompare(b);
-  });
+  .sort((a, b) => positionFor(a) - positionFor(b) || a.localeCompare(b));
 
 const out = [read(path.join(ROOT, 'scripts/llms-header.md')).trim(), ''];
 

--- a/static/llms.txt
+++ b/static/llms.txt
@@ -6,7 +6,7 @@ These docs describe the protocol, the cover products, how claims are assessed, a
 
 ## Start here
 
-- [Getting Started](https://docs.nexusmutual.io/): This documentation provides everything you need to know about Nexus Mutual.
+- [Getting Started](https://docs.nexusmutual.io/): Nexus Mutual is an onchain discretionary mutual.
 
 ## Overview
 
@@ -126,6 +126,7 @@ These docs describe the protocol, the cover products, how claims are assessed, a
 - [Depositing USDC](https://docs.nexusmutual.io/rwi-vault/depositing): Approved depositors may deposit USDC into the RWI Vault smart contract.
 - [Insurance Partners](https://docs.nexusmutual.io/rwi-vault/insurance-partners): The Vault Operator sources returns by depositing funds into offchain insurance opportunities, with a focus on short-tail lines — insurance business where the vast majority of claims are resolved within a relatively shorter timeframe after the policies themselves end.
 - [Withdrawals](https://docs.nexusmutual.io/rwi-vault/withdrawals): Withdrawals of RWIV into USDC are requested via the app by calling <code>requestRedeem()</code>.
+- [Governance](https://docs.nexusmutual.io/rwi-vault/governance): Who controls the RWI Vault, and what the contracts let each role do.
 - [Risks](https://docs.nexusmutual.io/rwi-vault/risks): The RWI Vault is exposed to risks from both Ethereum blockchain infrastructure and institutional insurance exposure.
 - [FAQs](https://docs.nexusmutual.io/rwi-vault/faqs): The Vault Operator generates returns by providing capital to carefully selected Insurance Partners.
 
@@ -142,3 +143,10 @@ These docs describe the protocol, the cover products, how claims are assessed, a
 
 - [Bonuses](https://docs.nexusmutual.io/rwi-vault/yield-structure/bonuses/): RWIV tokens can be locked in the Vault smart contracts for a specified duration to earn points.
 - [Net Asset Value Calculation](https://docs.nexusmutual.io/rwi-vault/yield-structure/bonuses/nav-calculation): At the end of every quarter (31/03, 30/06, 30/09, 31/12), the VO calculates total Net Asset Value ("NAV").
+
+### Contracts
+
+- [Contracts](https://docs.nexusmutual.io/rwi-vault/contracts/): The contracts behind the Real World Insurance Vault, and what an integration can and cannot rely on.
+- [RWIVault](https://docs.nexusmutual.io/rwi-vault/contracts/RWIVault): The RWIVault contract takes USDC deposits from approved depositors and issues RWIV, whose redemption value grows at a fixed per-second rate.
+- [Locks](https://docs.nexusmutual.io/rwi-vault/contracts/Locks): The Locks contract holds RWIV that members have committed for a fixed period, and pays out the bonuses that commitment earns.
+- [RWIRegistry](https://docs.nexusmutual.io/rwi-vault/contracts/RWIRegistry): The RWIRegistry contract is the vault system's address book, member register and pause switch.


### PR DESCRIPTION
The RWI Vault is a separate product from the Nexus Mutual protocol, with its own contracts and its own governance. The docs did not say so anywhere, had no developer documentation for it, and had never checked its member-facing pages against the deployed contracts. This does all three.

## Structure

The Vault's contract reference sat inside Developer Resources, next to the protocol contracts, which implied it was part of the protocol. Everything about the Vault now lives in the Vault's own section:

```
docs/rwi-vault/
  approval, depositing, insurance-partners, yield-structure, withdrawals
  governance      new
  risks
  contracts/      moved from docs/developers/rwi-vault/
  faqs
```

Developer Resources keeps a link to it, so a developer landing there still finds it. The front page and the Mutual's governance page now state the boundary rather than leaving a reader to assume either way.

## Governance

New page, because nothing described who controls the Vault.

Vault changes are not enacted through the protocol's `Governor` contract, and there is no proposal, Snapshot vote or member veto in the path of a Vault change. The page sets out the four roles that sit in the Vault's own `RWIRegistry` (governor, Vault Operator, membership operator, emergency admins), what each can do, and what no role can do: no administrative transfer or freeze of RWIV, no ending a lock early, no reordering the withdrawal queue, no rate change without 90 days' notice.

The page names the governor: the role is held by the Nexus Mutual Advisory Board multisig, acting on the Vault directly as a transaction on the Vault's own registry rather than through the protocol's proposal and member vote process. Naming it is the honest version of "separate governance" — the separation is in the contracts and the process, not in the people, and the address is one click from the registry either way.

It also says the contracts can be upgraded, that only the governor can upgrade them, and that an upgrade takes effect with no waiting period. That was missing everywhere, and `risks.md` now points at it — its Smart Contract Risk section listed code bugs, economic behaviour, congestion and reorgs, but never said the code could be replaced.

The mechanism behind that sits on the contract page rather than the member page: the vault and `Locks` proxies are owned by the registry, the registry's own proxy is owned by the governor directly, nothing in the chain has a timelock or a separate proxy admin, and the governor index cannot be reassigned, so replacing the governor needs a new registry implementation that only the current governor can ship.

## The contract reference

Four pages, written from the sources rather than from the standard:

- **Contracts** — how the three contracts and the registry fit together, membership, what of ERC-7540 is implemented, where the assets are, upgrades, pause
- **RWIVault** — requests, fulfilment, share price, rate changes, asset cap
- **Locks** — locking, editing, bonus payouts
- **RWIRegistry** — indexes, members, pause, upgrades

### Where the Vault diverges from ERC-7540

This is the part an integration would otherwise hit at runtime.

**The claim half of the standard does not exist.** `deposit`, `mint`, `withdraw`, `redeem`, `claimableDepositRequest`, `claimableRedeemRequest`, `setOperator` and `isOperator` all revert `NotSupported()`. Fulfilment mints or pays in the operator's own transaction, so nothing is ever left claimable. Code written against the request-then-claim sequence will not work.

Others worth knowing:

- `maxDeposit` and `maxMint` return `type(uint).max` and say nothing about the asset cap
- `totalAssets()` is what the Vault owes, not a balance it holds. The assets sit with the Vault Operator
- an unknown request id reads as a zeroed struct, and `PENDING` is zero, so a request that does not exist looks pending
- `getBaseApy()` returns a growth factor, not a percentage. `1.05e18` is 5%
- `executeBaseRateChange()` has no access control. The 90 day notice is the control, not the caller
- an unauthorised call from an unregistered address fails with `ContractDoesNotExist` from the registry, not `Unauthorized` from the contract being called

## What was wrong on the member pages

Two things did not match the contracts:

| Page | Said | Is |
|---|---|---|
| `depositing.md` | `requestDepositandLock()` | `requestDepositAndLock()` |
| `baseline-yield.md` | the RWIV value comes from `convertToShares()` | it comes from `convertToAssets()`. `convertToShares` goes the other way |

And these were simply absent, each of them material to someone holding a position:

- **requests can be cancelled**, both deposits and redemptions, while they are pending
- **RWIV leaves your wallet when you request a withdrawal**, so it cannot be transferred or sold while queued. The withdrawals page mentions a secondary market for instant exit without saying the queue closes that route
- **a pending deposit earns nothing.** Yield starts when the deposit is accepted, not when it is submitted
- **an over-cap deposit can be part accepted**, with the rest returned. The page presented it as accept or reject
- **a partly filled withdrawal keeps its place at the front of the queue**
- **a lock has no early exit.** It can be topped up or extended while running, but not ended

The lock bounds now state the real onchain range, 30 to 732 days, where the table starting at 90 implied a floor of 90. "LP tokens" is normalised to RWIV, which is what the token is called everywhere else. The vault cap keeps its launch figure of 10m USDC and adds a pointer to `assetCap` for the current one.

## Verification

The three reference pages are registered in the drift check, so every function they document is checked against the deployed ABI and every constant against mainnet:

```
rwi-vault/contracts/RWIVault.md      RWIVault      documented: 21  notOnABI: 0
rwi-vault/contracts/Locks.md         Locks         documented:  7  notOnABI: 0
rwi-vault/contracts/RWIRegistry.md   RWIRegistry   documented: 24  notOnABI: 0
```

Values verified goes from 37 to 49. `literal()` learns the `1.5e18` form the Vault uses for its rates and asset unit, which is what lets `WAD`, `MAX_APY` and `ASSET_UNIT` be asserted rather than skipped. `PAGES` keys are now relative to `docs/`, so the check can reach reference pages outside the developers section.

Two unrelated fixes came out of the same reading. The audits page pointed at `NexusMutual/rwa-vault`, which was renamed to `rwi-vault`, and the `llms.txt` generator ignored `_category_.json` positions, so any category without an index page sorted last regardless of where the sidebar puts it.

## One thing left open

**The 30 day minimum lock.** `Locks.MIN_LOCK_PERIOD` is 30 days, and under the points formula a 30 day lock earns 0.33x. The page now says so. Worth confirming that is intended and not a UI floor that was meant to be a contract floor.


## Not doing

Several Vault values are live state, not constants: `getBaseApy`, `getRatePerSecond`, `totalAssets`, `assetCap`, `getMemberCount`. None of them are written into any page. The baseline yield page already had this right by saying the current yield can be found on the app rather than quoting it.

