### PR TITLE
docs: align claim assessment history pages with review findings

### DIFF
--- a/docs/overview/claims-history/bzx-2020.md
+++ b/docs/overview/claims-history/bzx-2020.md
@@ -12,7 +12,7 @@ For a recap of the bZx flashloan event, you can [read the following summary](htt
 A total of $33,720.10  was paid out to bZx v1 Smart Contract Cover Holders. Smart Contract Cover has since been deprecated and replaced by Protocol Cover, an updated cover product that protects against more risks in DeFi.
 
 ## Overview
-After this hack occurred, claim assessors [discussed this loss event](https://discord.com/channels/496296560624140298/496296560624140302/678271971053797380) in the Mutual's Discord server. Because Nexus Mutual is a discretionary mutual, members participated in claims assessment, [the V1 process in place at the time](/protocol/claims-assessment#how-claim-assessment-has-changed), and review the validity of claims submitted after a loss event occurs.
+After this hack occurred, claim assessors [discussed this loss event](https://discord.com/channels/496296560624140298/496296560624140302/678271971053797380) in the Mutual's Discord server. Because Nexus Mutual is a discretionary mutual, members reviewed the validity of the claims submitted after this loss event under [the V1 process in place at the time](/protocol/claims-assessment#how-claim-assessment-has-changed).
 
 Members reviewed the information available after the hack occurred and the consensus was that this was a covered event, as it met the conditions outlined in the existing cover wording at the time of the hack.
 

--- a/docs/overview/claims-history/cream-2021.md
+++ b/docs/overview/claims-history/cream-2021.md
@@ -10,7 +10,7 @@ There is a full post-mortem of this loss event and the claim payouts in the [Pay
 A total of $397,087.31 was paid out to members including the Claim V1 #102 payout from the DAO treasury.
 
 ### Overview
-After this exploit occurred, claim assessors discussed this loss event in the Mutual's Discord server. Because Nexus Mutual is a discretionary mutual, members participated in claims assessment, [the V1 process in place at the time](/protocol/claims-assessment#how-claim-assessment-has-changed), and review the validity of claims submitted after a loss event occurs.
+After this exploit occurred, claim assessors discussed this loss event in the Mutual's Discord server. Because Nexus Mutual is a discretionary mutual, members reviewed the validity of the claims submitted after this loss event under [the V1 process in place at the time](/protocol/claims-assessment#how-claim-assessment-has-changed).
 
 Members reviewed the information available in the days after the exploit, while CREAM V1 Protocol Cover holders waited for the 72-hour cool-down period to pass before submitting claims. Claim assessors discussed the event and determined the CREAM V1 economic exploit was covered under sections 1.2 and 1.3 of the Protocol Cover wording.
 

--- a/docs/overview/claims-history/euler.md
+++ b/docs/overview/claims-history/euler.md
@@ -12,7 +12,7 @@ A total of $1m was paid out for the Sherlock Excess Cover Claim V2 #10, where [S
 
 ## Overview
 
-On Monday, 13 March 2023, [Euler Finance was exploited for $197m](https://twitter.com/FrankResearcher/status/1635241475989721089). After this exploit occurred, claim assessors [discussed this loss event in the Mutual's Discord server](https://discord.com/channels/496296560624140298/1084935082978070549/1084935082978070549). Because Nexus Mutual is a discretionary mutual, members participated in claims assessment, [the V2 process in place at the time](/protocol/claims-assessment#how-claim-assessment-has-changed), and review the validity of claims submitted after a loss event occurs.
+On Monday, 13 March 2023, [Euler Finance was exploited for $197m](https://twitter.com/FrankResearcher/status/1635241475989721089). After this exploit occurred, claim assessors [discussed this loss event in the Mutual's Discord server](https://discord.com/channels/496296560624140298/1084935082978070549/1084935082978070549). Because Nexus Mutual is a discretionary mutual, members reviewed the validity of the claims submitted after this loss event under [the V2 process in place at the time](/protocol/claims-assessment#how-claim-assessment-has-changed).
 
 Members reviewed the information available in the days after the exploit, while Euler Finance Protocol Cover holders waited for the 72-hour cool-down period to pass before submitting claims. Claim assessors discussed the event and determined the Euler Finance exploit was covered under [section 1.1 of the Protocol Cover wording](https://uploads-ssl.webflow.com/62d8193ce9880895261daf4a/63d0f4c4cca088730ac54ccc_ProtocolCoverv1.0.pdf).
 

--- a/docs/overview/claims-history/perpetual-2022.md
+++ b/docs/overview/claims-history/perpetual-2022.md
@@ -8,7 +8,7 @@ sidebar_position: 5
 A total of $377,147.19 was paid out for Claim V1 #118 and Claim V1 #119.
 
 ## Overview
-After this exploit occurred, claim assessors [discussed this loss event](https://discordapp.com/channels/496296560624140298/689385874265342056/980881247368806470) in the Mutual's Discord server. Because Nexus Mutual is a discretionary mutual, members participated in claims assessment, [the V1 process in place at the time](/protocol/claims-assessment#how-claim-assessment-has-changed), and review the validity of claims submitted after a loss event occurs.
+After this exploit occurred, claim assessors [discussed this loss event](https://discordapp.com/channels/496296560624140298/689385874265342056/980881247368806470) in the Mutual's Discord server. Because Nexus Mutual is a discretionary mutual, members reviewed the validity of the claims submitted after this loss event under [the V1 process in place at the time](/protocol/claims-assessment#how-claim-assessment-has-changed).
 
 Claim assessors discussed the event and determined the Perpetual Protocol v1 economic design failure event was covered under section 1.2 of the [Protocol Cover wording](https://uploads-ssl.webflow.com/62d8193ce9880895261daf4a/63d0f4c4cca088730ac54ccc_ProtocolCoverv1.0.pdf).
 

--- a/docs/overview/claims-history/rari-fuse-2022.md
+++ b/docs/overview/claims-history/rari-fuse-2022.md
@@ -8,7 +8,7 @@ sidebar_position: 4
 A total of $5,089,889.24 was paid out for Claims V1 #110, #111, and #113.
 
 ## Overview
-After this exploit occurred, claim assessors [discussed this loss event](https://discord.com/channels/496296560624140298/689385874265342056/970676366238425098) in the Mutual's Discord server. Because Nexus Mutual is a discretionary mutual, members participated in claims assessment, [the V1 process in place at the time](/protocol/claims-assessment#how-claim-assessment-has-changed), and review the validity of claims submitted after a loss event occurs.
+After this exploit occurred, claim assessors [discussed this loss event](https://discord.com/channels/496296560624140298/689385874265342056/970676366238425098) in the Mutual's Discord server. Because Nexus Mutual is a discretionary mutual, members reviewed the validity of the claims submitted after this loss event under [the V1 process in place at the time](/protocol/claims-assessment#how-claim-assessment-has-changed).
 
 Members reviewed the information available in the days after the exploit, while Rari Capital Protocol Cover holders waited for the 72-hour cool-down period to pass before submitting claims. Claim assessors discussed the event and determined the Rari Capital Fuse market exploit was covered under sections 1.1 of the [Protocol Cover wording](https://uploads-ssl.webflow.com/62d8193ce9880895261daf4a/63d0f4c4cca088730ac54ccc_ProtocolCoverv1.0.pdf).
 

--- a/docs/overview/claims-history/yearn-2021.md
+++ b/docs/overview/claims-history/yearn-2021.md
@@ -7,7 +7,7 @@ sidebar_position: 2
 A total of $2,317,776.72 was paid out to Yearn Finance Smart Contract Cover holders. Smart Contract Cover has since been deprecated and replaced by Protocol Cover, an updated cover product that protects against more risks in DeFi.
 
 ## Overview
-After this exploit occurred, claim assessors [discussed this loss event](https://discord.com/channels/496296560624140298/689385874265342056/807263979192713217) in the Mutual's Discord server. Because Nexus Mutual is a discretionary mutual, members participated in claims assessment, [the V1 process in place at the time](/protocol/claims-assessment#how-claim-assessment-has-changed), and review the validity of claims submitted after a loss event occurs.
+After this exploit occurred, claim assessors [discussed this loss event](https://discord.com/channels/496296560624140298/689385874265342056/807263979192713217) in the Mutual's Discord server. Because Nexus Mutual is a discretionary mutual, members reviewed the validity of the claims submitted after this loss event under [the V1 process in place at the time](/protocol/claims-assessment#how-claim-assessment-has-changed).
 
 Members reviewed the information available after the hack occurred and the consensus was that this was a covered event, as it met the conditions outlined in the existing cover wording at the time of the hack.
 

--- a/docs/protocol/claims-assessment.md
+++ b/docs/protocol/claims-assessment.md
@@ -61,7 +61,7 @@ These risk experts will review the incident details and proof of loss provided b
 Once you submit your claim, the Claims Committee will be alerted and begin their review.
 
 <!-- @check Assessments.minVotingPeriod = 3 days -->
-Any claim that is submitted will be open for voting for at least 72 hours. During that 72 hours, the Claims Committee will review the details provided, discuss the validity of your claim, and cast their votes. Each Assessor casts one vote, and a claim is accepted when accept votes outnumber deny votes: 2 of the 3 Claims Committee Assessors.
+Any claim that is submitted will be open for voting for at least 72 hours. During that 72 hours, the Claims Committee will review the details provided, discuss the validity of your claim, and cast their votes. Each Assessor casts one vote, and a majority of accept votes approves a claim: 2 of the 3 Claims Committee Assessors.
 
 Once the Claims Committee has cast their votes and the 72-hour period ends, voting on the claim will close.
 
@@ -98,7 +98,7 @@ You submit a claim with a 0.05 ETH claim deposit. See the [Claims contract refer
 ### What happened to the 70% consensus threshold and the 36-hour voting window?
 
 <!-- @check Assessments.minVotingPeriod = 3 days -->
-Those were V1 rules, retired in March 2023. Today, voting stays open for at least 72 hours. A majority of the three Claims Committee assessors must vote accept.
+Those were V1 rules, retired in March 2023. Today, voting stays open for at least 72 hours. A majority of accept votes approves a claim: 2 of the 3 Claims Committee assessors.
 
 ## Claims History
 

--- a/docs/protocol/claims-assessment.md
+++ b/docs/protocol/claims-assessment.md
@@ -7,7 +7,9 @@ description: The Claims Committee, three publicly known assessors, reviews and v
 
 <!-- @check Assessments.minVotingPeriod = 3 days -->
 <!-- @check Claims.CLAIM_DEPOSIT_IN_ETH = 0.05 ether -->
-Nexus Mutual pays claims through an expert-led assessment process. You submit a claim in the Nexus Mutual app, together with a 0.05 ETH claim deposit. The Claims Committee, three publicly known assessors, reviews your evidence and votes on your claim. Some cover products name a Designated Claim Assessor instead. Voting stays open for at least 72 hours. Each assessor casts one vote, and a majority of accept votes approves your claim: 2 of the 3 Committee assessors. After a 24-hour cool-down period, you can redeem an accepted payout for 30 days. Expert assessors have decided every claim since November 2025.
+Nexus Mutual pays claims through an expert-led assessment process. You submit a claim in the Nexus Mutual app, together with a 0.05 ETH claim deposit. The Claims Committee, three publicly known assessors, reviews your evidence and votes on your claim. Some cover products name a Designated Claim Assessor instead. Voting runs in a 72-hour window, and it closes early once all assessors have voted. Each assessor casts one vote, and a majority of accept votes approves your claim: 2 of the 3 Committee assessors. After a 24-hour cool-down period, you can redeem an accepted payout for 30 days. Expert assessors have decided every claim since November 2025.
+
+*Last reviewed: August 2026.*
 
 This page describes each step of the Claim Assessment process in detail.
 
@@ -61,9 +63,9 @@ These risk experts will review the incident details and proof of loss provided b
 Once you submit your claim, the Claims Committee will be alerted and begin their review.
 
 <!-- @check Assessments.minVotingPeriod = 3 days -->
-Any claim that is submitted will be open for voting for at least 72 hours. During that 72 hours, the Claims Committee will review the details provided, discuss the validity of your claim, and cast their votes. Each Assessor casts one vote, and a majority of accept votes approves a claim: 2 of the 3 Claims Committee Assessors.
+Any claim that is submitted opens a 72-hour voting window. During that window, the Claims Committee reviews the details provided, discusses the validity of your claim, and casts their votes. Each Assessor casts one vote, and a majority of accept votes approves a claim: 2 of the 3 Claims Committee Assessors. Once every assessor has voted, voting can close early. Governance can extend voting with a fresh 72-hour window.
 
-Once the Claims Committee has cast their votes and the 72-hour period ends, voting on the claim will close.
+Voting on the claim closes when the window ends.
 
 **Note**: The Claims Committee members are required to provide the rationale behind their decision to accept or deny a claim when they cast their vote. Claimants will be able to review this information after the voting period ends for a claim submission.
 
@@ -98,7 +100,7 @@ You submit a claim with a 0.05 ETH claim deposit. See the [Claims contract refer
 ### What happened to the 70% consensus threshold and the 36-hour voting window?
 
 <!-- @check Assessments.minVotingPeriod = 3 days -->
-Those were V1 rules, retired in March 2023. Today, voting stays open for at least 72 hours. A majority of accept votes approves a claim: 2 of the 3 Claims Committee assessors.
+Those were V1 rules, retired in March 2023. Today, a claim opens a 72-hour voting window. A majority of accept votes approves a claim: 2 of the 3 Claims Committee assessors.
 
 ## Claims History
 

--- a/docs/using/file-a-claim.md
+++ b/docs/using/file-a-claim.md
@@ -40,7 +40,8 @@ You review everything before it goes onchain.
 
 ## What happens next
 
-The Claims Committee reviews the claim and votes. Voting stays open for **at least 72 hours**, and assessors record the reasoning behind their vote, which you can read once voting closes.
+<!-- @check Assessments.minVotingPeriod = 3 days -->
+The Claims Committee reviews the claim and votes. Voting runs in a **72-hour window**, and assessors record the reasoning behind their vote, which you can read once voting closes.
 
 A **24-hour cooldown** follows, during which the Advisory Board can act if a vote was fraudulent.
 


### PR DESCRIPTION
Follow-up to #147, which merged with the first review fix wave included. This PR carries the remaining findings: it rewrites the member-participation sentence on six claims-history event pages in the past tense with a dated process link (V1 for bzX, Yearn, CREAM, Perpetual, Rari Fuse, V2 for Euler), restores the 2 of the 3 threshold in the history section's closing paragraph, and moves the Assessing Active Claims voting sentence to the active voice with the contract's majority rule.